### PR TITLE
Setup docs environment on CentOS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ group :development do
   gem 'rb-fsevent', '~> 0.9'
   gem 'stringex', '~> 1.4.0'
   gem 'jekyll-time-to-read'
+  gem 'execjs'
+  gem 'therubyracer', :platforms => :ruby
 end
 
 gem 'sinatra', '~> 1.4.2'


### PR DESCRIPTION
I noticed that for the setup of a local environment for building the documentation additional gems are needed. At least on CentOS 7.1.1503.