### PR TITLE
Refactor Getting Started page.

### DIFF
--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -102,7 +102,7 @@ h6:hover a.title-link {
 article.post, article.page, article.listing {
   img, table {
     border-radius: 3px;
-    box-shadow: rgba(0,0,0,0.06) 0 0 10px;    
+    box-shadow: rgba(0,0,0,0.06) 0 0 10px;
   }
 
   img.no-shadow {
@@ -120,7 +120,7 @@ article.post, article.page, article.listing {
     text-align: center;
     padding-bottom: 3px;
     font-size: .9rem;
-    box-shadow: rgba(0,0,0,0.06) 0 0 10px;    
+    box-shadow: rgba(0,0,0,0.06) 0 0 10px;
 
     img {
       display: block;
@@ -171,87 +171,13 @@ p.note {
 
   &.warning {
     background-color: #F7F9E1;
-    
+
     &::before {
       background-color: rgb(187, 185, 13);;
       content: "\f071" " Warning " attr(data-title);
     }
   }
 
-}
-
-.install-instructions-container {
-  #normal-install, #raspberry-install, #docker-install, .install-instructions {
-    display: none;
-  }
-
-  label.menu-selector {
-    display: inline-block;
-    text-align: center;
-    padding: 20px;
-    white-space: nowrap;
-    border-bottom: 5px solid $grayLight;
-    transition: border-bottom-color .5s;
-  }
-
-  label.menu-selector + label.menu-selector {
-    margin-left: 10px;
-  }
-
-  #normal-install:checked ~ .menu-selector.normal,
-  #raspberry-install:checked ~ .menu-selector.raspberry,
-  #docker-install:checked ~ .menu-selector.docker
-   {
-    border-bottom-color: $blue;
-  }
-
-  #normal-install:checked ~ .install-instructions.normal,
-  #raspberry-install:checked ~ .install-instructions.raspberry,
-  #docker-install:checked ~ .install-instructions.docker
-   {
-    display: block;
-  }
-
-  .install-instructions {
-    margin-top: 30px;
-  }
-}
-
-.prep-instructions-container {
-  #generic-prep, #fedora-prep, #centos-prep, .prep-instructions {
-    display: none;
-  }
-
-  label.menu-selector {
-    display: inline-block;
-    text-align: center;
-    padding: 10px;
-    white-space: nowrap;
-    border-bottom: 2px solid $grayLight;
-    transition: border-bottom-color .5s;
-  }
-
-  label.menu-selector + label.menu-selector {
-    margin-left: 10px;
-  }
-
-  #generic-prep:checked ~ .menu-selector.generic,
-  #fedora-prep:checked ~ .menu-selector.fedora,
-  #centos-prep:checked ~ .menu-selector.centos
-   {
-    border-bottom-color: $blue;
-  }
-
-  #generic-prep:checked ~ .prep-instructions.generic,
-  #fedora-prep:checked ~ .prep-instructions.fedora,
-  #centos-prep:checked ~ .prep-instructions.centos
-   {
-    display: block;
-  }
-
-  .prep-instructions {
-    margin-top: 20px;
-  }
 }
 
 .post-instructions-container {
@@ -292,3 +218,76 @@ p.note {
 
 }
 
+.install-channels-container {
+  #prod-channel, #beta-channel, #dev-channel, .install-channels {
+    display: none;
+  }
+
+  label.menu-selector {
+    display: inline-block;
+    text-align: center;
+    padding: 10px;
+    white-space: nowrap;
+    border-bottom: 2px solid $grayLight;
+    transition: border-bottom-color .5s;
+  }
+
+  label.menu-selector + label.menu-selector {
+    margin-left: 10px;
+  }
+
+  #prod-channel:checked ~ .menu-selector.prodchan,
+  #beta-channel:checked ~ .menu-selector.betachan,
+  #dev-channel:checked ~ .menu-selector.devchan
+   {
+    border-bottom-color: $blue;
+  }
+
+  #prod-channel:checked ~ .install-channels.prodchan,
+  #beta-channel:checked ~ .install-channels.betachan,
+  #dev-channel:checked ~ .install-channels.devchan
+   {
+    display: block;
+  }
+
+  .install-channels {
+    margin-top: 20px;
+  }
+}
+
+.advanced-installs-container {
+  #docker-install, #debian-install, #fedora-install, .advanced-installs {
+    display: none;
+  }
+
+  label.menu-selector {
+    display: inline-block;
+    text-align: center;
+    padding: 10px;
+    white-space: nowrap;
+    border-bottom: 2px solid $grayLight;
+    transition: border-bottom-color .5s;
+  }
+
+  label.menu-selector + label.menu-selector {
+    margin-left: 10px;
+  }
+
+  #docker-install:checked ~ .menu-selector.docker,
+  #debian-install:checked ~ .menu-selector.debian,
+  #fedora-install:checked ~ .menu-selector.fedora
+   {
+    border-bottom-color: $blue;
+  }
+
+  #docker-install:checked ~ .advanced-installs.docker,
+  #debian-install:checked ~ .advanced-installs.debian,
+  #fedora-install:checked ~ .advanced-installs.fedora
+   {
+    display: block;
+  }
+
+  .advanced-installs {
+    margin-top: 20px;
+  }
+}

--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -180,17 +180,17 @@ p.note {
 
 }
 
-.post-instructions-container {
-  #generic-post, #fedora-post, #debian-post, .post-instructions {
+.install-instructions-container {
+  #normal-install, #raspberry-install, #docker-install, .install-instructions {
     display: none;
   }
 
   label.menu-selector {
     display: inline-block;
     text-align: center;
-    padding: 10px;
+    padding: 20px;
     white-space: nowrap;
-    border-bottom: 2px solid $grayLight;
+    border-bottom: 5px solid $grayLight;
     transition: border-bottom-color .5s;
   }
 
@@ -198,65 +198,27 @@ p.note {
     margin-left: 10px;
   }
 
-  #generic-post:checked ~ .menu-selector.generic-post,
-  #fedora-post:checked ~ .menu-selector.fedora-post,
-  #debian-post:checked ~ .menu-selector.debian-post
+  #normal-install:checked ~ .menu-selector.normal,
+  #raspberry-install:checked ~ .menu-selector.raspberry,
+  #docker-install:checked ~ .menu-selector.docker
    {
     border-bottom-color: $blue;
   }
 
-  #generic-post:checked ~ .post-instructions.generic-post,
-  #fedora-post:checked ~ .post-instructions.fedora-post,
-  #debian-post:checked ~ .post-instructions.debian-post
+  #normal-install:checked ~ .install-instructions.normal,
+  #raspberry-install:checked ~ .install-instructions.raspberry,
+  #docker-install:checked ~ .install-instructions.docker
    {
     display: block;
   }
 
-  .post-instructions {
-    margin-top: 20px;
-  }
-
-}
-
-.install-channels-container {
-  #prod-channel, #beta-channel, #dev-channel, .install-channels {
-    display: none;
-  }
-
-  label.menu-selector {
-    display: inline-block;
-    text-align: center;
-    padding: 10px;
-    white-space: nowrap;
-    border-bottom: 2px solid $grayLight;
-    transition: border-bottom-color .5s;
-  }
-
-  label.menu-selector + label.menu-selector {
-    margin-left: 10px;
-  }
-
-  #prod-channel:checked ~ .menu-selector.prodchan,
-  #beta-channel:checked ~ .menu-selector.betachan,
-  #dev-channel:checked ~ .menu-selector.devchan
-   {
-    border-bottom-color: $blue;
-  }
-
-  #prod-channel:checked ~ .install-channels.prodchan,
-  #beta-channel:checked ~ .install-channels.betachan,
-  #dev-channel:checked ~ .install-channels.devchan
-   {
-    display: block;
-  }
-
-  .install-channels {
-    margin-top: 20px;
+  .install-instructions {
+    margin-top: 30px;
   }
 }
 
 .advanced-installs-container {
-  #docker-install, #debian-install, #fedora-install, .advanced-installs {
+  #debian-install, #fedora-install, .advanced-installs {
     display: none;
   }
 
@@ -273,14 +235,12 @@ p.note {
     margin-left: 10px;
   }
 
-  #docker-install:checked ~ .menu-selector.docker,
   #debian-install:checked ~ .menu-selector.debian,
   #fedora-install:checked ~ .menu-selector.fedora
    {
     border-bottom-color: $blue;
   }
 
-  #docker-install:checked ~ .advanced-installs.docker,
   #debian-install:checked ~ .advanced-installs.debian,
   #fedora-install:checked ~ .advanced-installs.fedora
    {

--- a/sass/custom/_paulus.scss
+++ b/sass/custom/_paulus.scss
@@ -218,16 +218,17 @@ p.note {
 }
 
 .advanced-installs-container {
-  #debian-install, #fedora-install, .advanced-installs {
+
+  #upstart-install, #systemd-install, .advanced-installs {
     display: none;
   }
 
   label.menu-selector {
     display: inline-block;
     text-align: center;
-    padding: 10px;
+    padding: 20px;
     white-space: nowrap;
-    border-bottom: 2px solid $grayLight;
+    border-bottom: 5px solid $grayLight;
     transition: border-bottom-color .5s;
   }
 
@@ -235,19 +236,19 @@ p.note {
     margin-left: 10px;
   }
 
-  #debian-install:checked ~ .menu-selector.debian,
-  #fedora-install:checked ~ .menu-selector.fedora
+  #upstart-install:checked ~ .menu-selector.upstart,
+  #systemd-install:checked ~ .menu-selector.systemd
    {
     border-bottom-color: $blue;
   }
 
-  #debian-install:checked ~ .advanced-installs.debian,
-  #fedora-install:checked ~ .advanced-installs.fedora
+  #upstart-install:checked ~ .advanced-installs.upstart,
+  #systemd-install:checked ~ .advanced-installs.systemd
    {
     display: block;
   }
 
   .advanced-installs {
-    margin-top: 20px;
+    margin-top: 30px;
   }
 }

--- a/source/getting-started/advanced.markdown
+++ b/source/getting-started/advanced.markdown
@@ -12,34 +12,46 @@ footer: true
 Here are some general tutorials on how to setup some of the more advanced deployments that are frequently requested.
 
 <div class='advanced-installs-container'>
-<input name='advanced-installs' type='radio' id='debian-install' checked>
-<input name='advanced-installs' type='radio' id='fedora-install'>
-<label class='menu-selector debian' for='debian-install'>Debian (Ubuntu, Raspbian) Daemon</label>
-<label class='menu-selector fedora' for='fedora-install'>Fedora (RHEL, CentOS) Daemon</label>
+<input name='advanced-installs' type='radio' id='upstart-install' checked>
+<input name='advanced-installs' type='radio' id='systemd-install'>
+<label class='menu-selector upstart' for='upstart-install'>Upstart Daemon</label>
+<label class='menu-selector systemd' for='systemd-install'>Systemd Daemon</label>
 
-<div class='advanced-installs debian'>
-**Debian Deamon**
-<p>Debian based systems, including Ubuntu and Raspbian for the Raspberry Pi use an application called Init to manage daemon services. Init will launch init scripts that are located in the directory <code>/etc/init.d/</code>. A sample init script for Debian based systems is <a href="https://raw.githubusercontent.com/balloob/home-assistant/dev/scripts/hass-daemon">maintained in this project</a>.</p>
 
-<p>To install this script, download it, tweak it to you liking, and install it by following the directions in the header. This script will setup Home Assistant to run when the system boots. To start/stop Home Assistant manually, issue the following commands:
+<div class='advanced-installs upstart'>
+Many linux distributions use the Upstart system (or similar) for managing daemons. Typically, systems based on Debian 7 or previous use Upstart. This includes Ubuntu releases before 15.04 and all current Raspian releases. If you are unsure if your system is using Upstart, you may check with the following command:
+
+```bash
+ps -p 1 -o comm=
+```
+
+If the preceding command returns the string `init`, you are likely using Upstart.
+
+Upstart will launch init scripts that are located in the directory <code>/etc/init.d/</code>. A sample init script for systems using Upstart is <a href="https://raw.githubusercontent.com/balloob/home-assistant/dev/scripts/hass-daemon">maintained by this project</a>.
+
+To install this script, download it, tweak it to you liking, and install it by following the directions in the header. This script will setup Home Assistant to run when the system boots. To start/stop Home Assistant manually, issue the following commands:
 ```bash
 sudo service hass-daemon start
 sudo service hass-daemon stop
 ```
-</p>
 
-<p>When running Home Assistant with this script, the configuration directory will be located at <code>/var/opt/homeassistant</code>. This directory will contain a verbose log rather than simply an error log.</p>
+When running Home Assistant with this script, the configuration directory will be located at <code>/var/opt/homeassistant</code>. This directory will contain a verbose log rather than simply an error log.
 
-<p>When running daemons, it is good practice to have the daemon run under its own user name rather than the default user's name. Instructions for setting this up are outside the scope of this document.</p>
-</div> <!-- DEBIAN -->
+When running daemons, it is good practice to have the daemon run under its own user name rather than the default user's name. Instructions for setting this up are outside the scope of this document.
+</div> <!-- UPSTART -->
 
-<div class='advanced-installs fedora'>
-**Fedora Daemon**
-<p>If you want that Home Assistant is lauched automatically, an extra step is needed to setup <code>systemd</code>. You need a service file to control Home Assistant with <code>systemd</code>. <!-- The <code>WorkingDirectory</code> and the <code>PYTHONPATH</code> must point to your clone git repository. --></p>
 
-<!-- WorkingDirectory=/home/fab/home-assistant/
-Environment="PYTHONPATH=/home/fab/home-assistant/" -->
 
+<div class='advanced-installs systemd'>
+Newer linux distributions are trending towards using systemd for managing daemons. Typically, systems based on Fedora or Debian 8 or later use systemd. This includes Ubuntu releases including and after 15.04, CentOS, and Red Hat. If you are unsure if your system is using systemd, you may check with the following command:
+
+```bash
+ps -p 1 -o comm=
+```
+
+If the preceding command returns the string `systemd`, you are likely using systemd.
+
+If you want Home Assistant to be launched automatically, an extra step is needed to setup systemd. You need a service file to control Home Assistant with systemd.
 
 ```bash
 su -c 'cat <<EOF >> /lib/systemd/system/home-assistant.service
@@ -56,7 +68,7 @@ WantedBy=multi-user.target
 EOF'
 ```
 
-<p>You need to reload <code>systemd</code> to make the daemon aware of the new configuration. Enable and launch Home Assistant after that.</p>
+You need to reload systemd to make the daemon aware of the new configuration. Enable and launch Home Assistant after that.
 
 ```bash
 sudo systemctl --system daemon-reload
@@ -64,7 +76,7 @@ sudo systemctl enable home-assistant
 sudo systemctl start home-assistant
 ```
 
-<p>If everything went well, <code>sudo systemctl start home-assistant</code> should give you a positive feedback.</p>
+If everything went well, <code>sudo systemctl start home-assistant</code> should give you a positive feedback.
 
 ```bash
 $ sudo systemctl status home-assistant -l
@@ -77,11 +89,11 @@ $ sudo systemctl status home-assistant -l
 [...]
 ```
 
-<p>To get Home Assistant's logging output, simple use <code>journalctl</code>.</p>
+To get Home Assistant's logging output, simple use <code>journalctl</code>.
 
 ```bash
 sudo journalctl -f -u home-assistant
 ```
-</div> <!-- FEDORA -->
+</div> <!-- SYSTEMD -->
 
 ###[&laquo; Back to Getting Started](/getting-started/index.html)

--- a/source/getting-started/advanced.markdown
+++ b/source/getting-started/advanced.markdown
@@ -12,27 +12,10 @@ footer: true
 Here are some general tutorials on how to setup some of the more advanced deployments that are frequently requested.
 
 <div class='advanced-installs-container'>
-<input name='advanced-installs' type='radio' id='docker-install' checked>
-<input name='advanced-installs' type='radio' id='debian-install'>
+<input name='advanced-installs' type='radio' id='debian-install' checked>
 <input name='advanced-installs' type='radio' id='fedora-install'>
-<label class='menu-selector docker' for='docker-install'>Docker Installation</label>
 <label class='menu-selector debian' for='debian-install'>Debian (Ubuntu, Raspbian) Daemon</label>
 <label class='menu-selector fedora' for='fedora-install'>Fedora (RHEL, CentOS) Daemon</label>
-
-<div class='advanced-installs docker'>
-**Docker Deployment**
-<p>Installation with Docker is straightforward. Adjust the following command so that <code>/path/to/your/config/</code> points at the folder where you want to store your config and run it:</p>
-
-```bash
-docker run -d --name="home-assistant" -v /path/to/your/config:/config -v /etc/localtime:/etc/localtime:ro --net=host balloob/home-assistant
-```
-
-<p>This will launch Home Assistant and serve its web interface from port 8123 on your Docker host.</p>
-
-<p class='note'>
-When using boot2docker on OS X you are unable to map the local time to your Docker container. Replace <code>-v /etc/localtime:/etc/localtime:ro</code> with <code>-e "TZ=America/Los_Angeles"</code> (replacing America/Los_Angeles with <a href='http://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>your timezone</a>)
-</p>
-</div> <!-- DOCKER -->
 
 <div class='advanced-installs debian'>
 **Debian Deamon**

--- a/source/getting-started/advanced.markdown
+++ b/source/getting-started/advanced.markdown
@@ -1,0 +1,104 @@
+---
+layout: page
+title: "Advanced Installation"
+description: "Brief advanced installation tutorials."
+date: 2015-9-1 22:57
+sidebar: false
+comments: false
+sharing: true
+footer: true
+---
+
+Here are some general tutorials on how to setup some of the more advanced deployments that are frequently requested.
+
+<div class='advanced-installs-container'>
+<input name='advanced-installs' type='radio' id='docker-install' checked>
+<input name='advanced-installs' type='radio' id='debian-install'>
+<input name='advanced-installs' type='radio' id='fedora-install'>
+<label class='menu-selector docker' for='docker-install'>Docker Installation</label>
+<label class='menu-selector debian' for='debian-install'>Debian (Ubuntu, Raspbian) Daemon</label>
+<label class='menu-selector fedora' for='fedora-install'>Fedora (RHEL, CentOS) Daemon</label>
+
+<div class='advanced-installs docker'>
+**Docker Deployment**
+<p>Installation with Docker is straightforward. Adjust the following command so that <code>/path/to/your/config/</code> points at the folder where you want to store your config and run it:</p>
+
+```bash
+docker run -d --name="home-assistant" -v /path/to/your/config:/config -v /etc/localtime:/etc/localtime:ro --net=host balloob/home-assistant
+```
+
+<p>This will launch Home Assistant and serve its web interface from port 8123 on your Docker host.</p>
+
+<p class='note'>
+When using boot2docker on OS X you are unable to map the local time to your Docker container. Replace <code>-v /etc/localtime:/etc/localtime:ro</code> with <code>-e "TZ=America/Los_Angeles"</code> (replacing America/Los_Angeles with <a href='http://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>your timezone</a>)
+</p>
+</div> <!-- DOCKER -->
+
+<div class='advanced-installs debian'>
+**Debian Deamon**
+<p>Debian based systems, including Ubuntu and Raspbian for the Raspberry Pi use an application called Init to manage daemon services. Init will launch init scripts that are located in the directory <code>/etc/init.d/</code>. A sample init script for Debian based systems is <a href="https://raw.githubusercontent.com/balloob/home-assistant/dev/scripts/hass-daemon">maintained in this project</a>.</p>
+
+<p>To install this script, download it, tweak it to you liking, and install it by following the directions in the header. This script will setup Home Assistant to run when the system boots. To start/stop Home Assistant manually, issue the following commands:
+```bash
+sudo service hass-daemon start
+sudo service hass-daemon stop
+```
+</p>
+
+<p>When running Home Assistant with this script, the configuration directory will be located at <code>/var/opt/homeassistant</code>. This directory will contain a verbose log rather than simply an error log.</p>
+
+<p>When running daemons, it is good practice to have the daemon run under its own user name rather than the default user's name. Instructions for setting this up are outside the scope of this document.</p>
+</div> <!-- DEBIAN -->
+
+<div class='advanced-installs fedora'>
+**Fedora Daemon**
+<p>If you want that Home Assistant is lauched automatically, an extra step is needed to setup <code>systemd</code>. You need a service file to control Home Assistant with <code>systemd</code>. <!-- The <code>WorkingDirectory</code> and the <code>PYTHONPATH</code> must point to your clone git repository. --></p>
+
+<!-- WorkingDirectory=/home/fab/home-assistant/
+Environment="PYTHONPATH=/home/fab/home-assistant/" -->
+
+
+```bash
+su -c 'cat <<EOF >> /lib/systemd/system/home-assistant.service
+[Unit]
+Description=Home Assistant
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=hass
+
+[Install]
+WantedBy=multi-user.target
+EOF'
+```
+
+<p>You need to reload <code>systemd</code> to make the daemon aware of the new configuration. Enable and launch Home Assistant after that.</p>
+
+```bash
+sudo systemctl --system daemon-reload
+sudo systemctl enable home-assistant
+sudo systemctl start home-assistant
+```
+
+<p>If everything went well, <code>sudo systemctl start home-assistant</code> should give you a positive feedback.</p>
+
+```bash
+$ sudo systemctl status home-assistant -l
+● home-assistant.service - Home Assistant
+   Loaded: loaded (/usr/lib/systemd/system/home-assistant.service; disabled; vendor preset: disabled)
+   Active: active (running) since Thu 2015-06-25 23:38:37 CEST; 3min 13s ago
+ Main PID: 8557 (python3.4)
+   CGroup: /system.slice/home-assistant.service
+           └─8557 /usr/bin/python3.4 -m homeassistant
+[...]
+```
+
+<p>To get Home Assistant's logging output, simple use <code>journalctl</code>.</p>
+
+```bash
+sudo journalctl -f -u home-assistant
+```
+</div> <!-- FEDORA -->
+
+###[&laquo; Back to Getting Started](/getting-started/index.html)

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -54,7 +54,7 @@ When using boot2docker on OS X you are unable to map the local time to your Dock
 
 
 <div class='install-instructions raspberry'>
-<p>Home Assistant uses Python 3.4 which is not shipped with the current Raspbian distibution for the Raspberry Pi. Before installing Home Assistant, you will have to <a href="http://depado.markdownblog.com/2015-03-12-short-tutorial-raspbian-python3-4-rpi-gpio"> target="_blank"install Python 3.4</a>.
+<p>Home Assistant uses Python 3.4 which is not shipped with the current Raspbian distibution for the Raspberry Pi. Before installing Home Assistant, you will have to <a href="http://depado.markdownblog.com/2015-03-12-short-tutorial-raspbian-python3-4-rpi-gpio" target="_blank">install Python 3.4</a>.
 
 Once that is complete, installing and running Home Assistant on your local machine is easy. Make sure you have <a href='https://www.python.org/downloads/' target="_blank">Python 3.4</a> installed and execute the following code in a console:
 

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -9,79 +9,67 @@ sharing: true
 footer: true
 ---
 
-<h3>Requirements</h3>
-<p>Home Assistant requires at least <a href="https://www.python.org/downloads/" target="_blank">Python 3.4</a>. For the Raspberry Pi, install instructions can be found <a href="http://depado.markdownblog.com/2015-03-12-short-tutorial-raspbian-python3-4-rpi-gpio" target="_blank">here</a>. Other systems generally have this bundled or contain easy to install packages.</p>
-
-<p>To ensure Python 3.4 is installed, type the following command into the console:</p>
-
-```bash
-python3 --version
-```
+<div class='install-instructions-container'>
+<input name='install-instructions' type='radio' id='normal-install' checked>
+<input name='install-instructions' type='radio' id='raspberry-install'>
+<input name='install-instructions' type='radio' id='docker-install'>
+<label class='menu-selector normal' for='normal-install'>Install on local machine</label>
+<label class='menu-selector raspberry' for='raspberry-install'>Install on a Raspberry Pi</label>
+<label class='menu-selector docker' for='docker-install'>Install using Docker</label>
 
 
 <h3>Installation</h3>
-<div class='install-channels-container'>
-<input name='install-channels' type='radio' id='prod-channel' checked>
-<input name='install-channels' type='radio' id='beta-channel'>
-<input name='install-channels' type='radio' id='dev-channel'>
-<label class='menu-selector prodchan' for='prod-channel'>Production Channel</label>
-<label class='menu-selector betachan' for='beta-channel'>Beta Channel</label>
-<label class='menu-selector devchan' for='dev-channel'>Development Channel</label>
 
-<div class='install-channels prodchan'>
-<p>Installing from the production channel is fast, easy, and will provide you with access to the newest stable builds. This is recommended for most users. To install, execute the following code in a console:</p>
+
+<div class='install-instructions normal'>
+Installing and running Home Assistant on your local machine is easy. Make sure you have <a href='https://www.python.org/downloads/' target="_blank">Python 3.4</a> installed and execute the following code in a console:
+
+<p>
 ```bash
 pip3 install homeassistant
 hass --open-ui
 ```
-<p>Running these commands will:
+</p>
+<p>Running these commands will:</p>
 <ol>
 <li>Install Home Assistant</li>
-<li>Launch Home Assistant and serve web interface on <a href='http://localhost:8123'>http://localhost:8123</a></li>
-</ol></p>
-<p>When new stable versions are released, you can upgrade to newest version by typing the following into a console:</p>
-```bash
-pip3 install --upgrade homeassistant
-```
-</div>
+<li>Launch Home Assistant and serve web interface on <a href='http://localhost:8123' target="_blank">http://localhost:8123</a></li>
+</ol>
+</div> <!-- INSTALL-INSTRUCTIONS NORMAL -->
 
-<div class='install-channels betachan'>
-<p>The beta channel will provide you with newer features sooner but at the risk of reduced stability. The brave and curious are welcomed here. To install, execute the following code in a console:</p>
+
+<div class='install-instructions docker'>
+<p>Installation with Docker is straightforward. Adjust the following command so that <code>/path/to/your/config/</code> points at the folder where you want to store your config and run it:</p>
+
 ```bash
-pip3 install --pre homeassistant
+docker run -d --name="home-assistant" -v /path/to/your/config:/config -v /etc/localtime:/etc/localtime:ro --net=host balloob/home-assistant
+```
+
+<p>This will launch Home Assistant and serve its web interface from port 8123 on your Docker host.</p>
+
+<p class='note'>
+When using boot2docker on OS X you are unable to map the local time to your Docker container. Replace <code>-v /etc/localtime:/etc/localtime:ro</code> with <code>-e "TZ=America/Los_Angeles"</code> (replacing America/Los_Angeles with <a href='http://en.wikipedia.org/wiki/List_of_tz_database_time_zones' target="_blank">your timezone</a>)
+</p>
+</div> <!-- INSTALL-INSTRUCTIONS DOCKER -->
+
+
+<div class='install-instructions raspberry'>
+<p>Home Assistant uses Python 3.4 which is not shipped with the current Raspbian distibution for the Raspberry Pi. Before installing Home Assistant, you will have to <a href="http://depado.markdownblog.com/2015-03-12-short-tutorial-raspbian-python3-4-rpi-gpio"> target="_blank"install Python 3.4</a>.
+
+Once that is complete, installing and running Home Assistant on your local machine is easy. Make sure you have <a href='https://www.python.org/downloads/' target="_blank">Python 3.4</a> installed and execute the following code in a console:
+
+<p>
+```bash
+pip3 install homeassistant
 hass --open-ui
 ```
-<p>Running these commands will:
+</p>
+<p>Running these commands will:</p>
 <ol>
 <li>Install Home Assistant</li>
-<li>Launch Home Assistant and serve web interface on <a href='http://localhost:8123'>http://localhost:8123</a></li>
-</ol></p>
-<p>When new a new release candidate, alpha, or beta version is released, you can upgrade to newest version by typing the following into a console:</p>
-```bash
-pip3 install --pre --upgrade homeassistant
-```
-</div>
-
-<div class='install-channels devchan'>
-<p>The development channel provides builds that are on the bleeding edge. This builds have not been fully tested or used. This is best for potential contributors and tinkerers. Subscribing to this channel is not for the faint of heart and requires significant knowledge of Git and Python.</p>
-```bash
-# Clone repo from git, you may want to use your own fork
-git clone --recursive https://github.com/balloob/home-assistant.git
-cd home-assistant
-# You may want to switch to a virtual environment here
-# Install Home Assistant in development mode
-python3 setup.py develop
-# Optionally pre-emptively install all possible dependencies
-pip3 install -r requirements_all.txt
-```
-<p>To keep up-to-date with the development channel, you will have to fetch and merge from the dev branch in the head repository. Be careful when doing this.</p>
-```bash
-git fetch balloob
-git merge remotes/balloob/dev
-```
-</div>
-
-</div><!-- install-channels-container -->
+<li>Launch Home Assistant and serve web interface on <a href='http://localhost:8123' target="_blank">http://localhost:8123</a></li>
+</ol>
+</div> <!-- INSTALL-INSTRUCTIONS RASPBERRY -->
 
 
 <h3>Troubleshooting</h3>
@@ -96,10 +84,19 @@ git merge remotes/balloob/dev
 </ul>
 </p>
 
+<h3>Staying Up to Date</h3>
+<p>In order to update Home Assistant to the latest stable release, simply type the following into a console:</p>
+```bash
+pip install --upgrade homeassistant
+```
+<p>If you would like to stay up to date with the newest unstable builds (alphas, betas, and release candidates), use this command:</p>
+```bash
+pip install --upgrade --pre homeassistant
+```
 
 <h3>What's Next</h3>
 <p>If you want to see what Home Assistant can do, you can start the demo mode by running <code>hass --demo-mode</code>. Home Assistant has a few other command line flags that can be displayed by running <code>hass --help</code>.</p>
-<p>From here you may now start configuring Home Assistant to your liking. For more advanced users, the <a href='{{site_root}}/getting-started/advanced.html'>advanced configuration page</a> contains brief tutorials on creating more advanced installations such as installing daemons and using Docker.</p>
+<p>From here you may now start configuring Home Assistant to your liking. For more advanced users, the <a href='{{site_root}}/getting-started/advanced.html'>advanced configuration page</a> contains brief tutorials on creating more advanced installations.</p>
 
 
 ###[Next step: configuring Home Assistant &raquo;](/getting-started/configuration.html)

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -27,7 +27,7 @@ Installing and running Home Assistant on your local machine is easy. Make sure y
 <p>
 ```bash
 pip3 install homeassistant
-hass --open-ui
+hass \-\-open-ui
 ```
 </p>
 <p>Running these commands will:</p>
@@ -42,7 +42,7 @@ hass --open-ui
 <p>Installation with Docker is straightforward. Adjust the following command so that <code>/path/to/your/config/</code> points at the folder where you want to store your config and run it:</p>
 
 ```bash
-docker run -d --name="home-assistant" -v /path/to/your/config:/config -v /etc/localtime:/etc/localtime:ro --net=host balloob/home-assistant
+docker run -d \-\-name="home-assistant" -v /path/to/your/config:/config -v /etc/localtime:/etc/localtime:ro \-\-net=host balloob/home-assistant
 ```
 
 <p>This will launch Home Assistant and serve its web interface from port 8123 on your Docker host.</p>
@@ -61,7 +61,7 @@ Once that is complete, installing and running Home Assistant on your local machi
 <p>
 ```bash
 pip3 install homeassistant
-hass --open-ui
+hass \-\-open-ui
 ```
 </p>
 <p>Running these commands will:</p>
@@ -87,15 +87,15 @@ hass --open-ui
 <h3>Staying Up to Date</h3>
 <p>In order to update Home Assistant to the latest stable release, simply type the following into a console:</p>
 ```bash
-pip install --upgrade homeassistant
+pip install \-\-upgrade homeassistant
 ```
 <p>If you would like to stay up to date with the newest unstable builds (alphas, betas, and release candidates), use this command:</p>
 ```bash
-pip install --upgrade --pre homeassistant
+pip install \-\-upgrade \-\-pre homeassistant
 ```
 
 <h3>What's Next</h3>
-<p>If you want to see what Home Assistant can do, you can start the demo mode by running <code>hass --demo-mode</code>. Home Assistant has a few other command line flags that can be displayed by running <code>hass --help</code>.</p>
+<p>If you want to see what Home Assistant can do, you can start the demo mode by running <code>hass \-\-demo-mode</code>. Home Assistant has a few other command line flags that can be displayed by running <code>hass \-\-help</code>.</p>
 <p>From here you may now start configuring Home Assistant to your liking. For more advanced users, the <a href='{{site_root}}/getting-started/advanced.html'>advanced configuration page</a> contains brief tutorials on creating more advanced installations.</p>
 
 

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -74,7 +74,7 @@ hass \-\-open-ui
 
 <h3>Troubleshooting</h3>
 
-<p>If you run into any issues, please see the <a href='{{site_root}}/getting-started/troubleshooting.html'>troubleshooting page</a>. It contains solutions to many of the common issues.</p>
+<p>If you run into any issues, please see the <a href='{{site_root}}/getting-started/troubleshooting.html'>troubleshooting page</a>. It contains solutions to many of the more commonly encountered issues.</p>
 
 <p>For additional help, in addition to this site, there are three sources:
 <ul>
@@ -99,4 +99,4 @@ pip install \-\-upgrade \-\-pre homeassistant
 <p>From here you may now start configuring Home Assistant to your liking. For more advanced users, the <a href='{{site_root}}/getting-started/advanced.html'>advanced configuration page</a> contains brief tutorials on creating more advanced installations.</p>
 
 
-###[Next step: configuring Home Assistant &raquo;](/getting-started/configuration.html)
+###[Next step: Configuring Home Assistant &raquo;](/getting-started/configuration.html)

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -9,284 +9,97 @@ sharing: true
 footer: true
 ---
 
-<div class='install-instructions-container'>
-<input name='install-instructions' type='radio' id='normal-install' checked>
-<input name='install-instructions' type='radio' id='raspberry-install'>
-<input name='install-instructions' type='radio' id='docker-install'>
-<label class='menu-selector normal' for='normal-install'>Install on local machine</label>
-<label class='menu-selector raspberry' for='raspberry-install'>Install on a Raspberry Pi</label>
-<label class='menu-selector docker' for='docker-install'>Install using Docker</label>
-<div class='install-instructions normal'>
+<h3>Requirements</h3>
+<p>Home Assistant requires at least <a href="https://www.python.org/downloads/" target="_blank">Python 3.4</a>. For the Raspberry Pi, install instructions can be found <a href="http://depado.markdownblog.com/2015-03-12-short-tutorial-raspbian-python3-4-rpi-gpio" target="_blank">here</a>. Other systems generally have this bundled or contain easy to install packages.</p>
 
-<h3>Preparation</h3>
-<!-- ###### Preparation START ######################## -->
-<div class='prep-instructions-container'>
-<input name='prep-instructions' type='radio' id='generic-prep' checked>
-<input name='prep-instructions' type='radio' id='fedora-prep'>
-<input name='prep-instructions' type='radio' id='centos-prep'>
-<label class='menu-selector generic' for='generic-prep'>Generic</label>
-<label class='menu-selector fedora' for='fedora-prep'>Fedora</label>
-<label class='menu-selector centos' for='centos-prep'>CentOS</label>
-
-<!-- ###### Preparation instructions Generic ######################## -->
-<div class='prep-instructions generic'>
-Installing and running Home Assistant on your local machine is easy. Make sure you have <a href='https://www.python.org/downloads/'>Python 3.4</a> installed and execute the following code in a console:
-
-
-</div>
-<!-- ###### Preparation instructions Fedora ######################## -->
-<div class='prep-instructions fedora'>
-<p>The preparation of a <a href='https://fedoraproject.org'>Fedora</a> 22 host will only take a couple of minutes. First install Python 3.4 and the other needed packages out of the <a href='https://admin.fedoraproject.org/pkgdb'>Fedora Package Collection</a>. This ensure that you receive updates in the future.</p>
-
-<p class='note'>
-It's assumed that your user has an entry in the sudoers file. Otherwise, run the commands which needs more privileges as root.
-</p>
+<p>To ensure Python 3.4 is installed, type the following command into the console:</p>
 
 ```bash
-sudo dnf -y install python3 python3-devel gcc
+python3 --version
 ```
 
-</div>
-<!-- ##### Preparation instructions Centos ######################### -->
-<div class='prep-instructions centos'>
-
-<p><a href='https://www.centos.org/'>CentOS</a> is providing longtime support and often not shipping the latest release of a software component. To run, Python 3.x on CentOS <a href='https://www.softwarecollections.org/en/scls/rhscl/rh-python34/'>Software Collections</a> needs to be activated.</p>
-
-<h5>Step 1. Install the tools for the Software Collection</h5>
-
-```bash
-sudo yum -y install scl-utils
-```
-
-<h5>Step 2. Make the repository available.</h5>
-
-```bash
-sudo yum -y install https://www.softwarecollections.org/en/scls/rhscl/rh-python34/epel-7-x86_64/download/rhscl-rh-python34-epel-7-x86_64.noarch.rpm
-```
-
-<h5>Step 3. Install Python 3.x</h5>
-
-```bash
-sudo yum -y install rh-python34
-```
-
-<h5>Step 4. Start using software collections:</h5>
-
-```bash
-scl enable rh-python34 bash
-```
-
-</div>
-
-</div>
-
-<br />
-<!-- ###### Preparation END ######################## -->
 
 <h3>Installation</h3>
+<div class='install-channels-container'>
+<input name='install-channels' type='radio' id='prod-channel' checked>
+<input name='install-channels' type='radio' id='beta-channel'>
+<input name='install-channels' type='radio' id='dev-channel'>
+<label class='menu-selector prodchan' for='prod-channel'>Production Channel</label>
+<label class='menu-selector betachan' for='beta-channel'>Beta Channel</label>
+<label class='menu-selector devchan' for='dev-channel'>Development Channel</label>
 
-<p>
+<div class='install-channels prodchan'>
+<p>Installing from the production channel is fast, easy, and will provide you with access to the newest stable builds. This is recommended for most users. To install, execute the following code in a console:</p>
 ```bash
 pip3 install homeassistant
 hass --open-ui
 ```
-</p>
-<p>Running these commands will:</p>
+<p>Running these commands will:
 <ol>
 <li>Install Home Assistant</li>
 <li>Launch Home Assistant and serve web interface on <a href='http://localhost:8123'>http://localhost:8123</a></li>
-</ol>
-<br />
-
-<!-- ###### Post-Installation START ######################## -->
-<h3>Post-Installation</h3>
-
-<div class='post-instructions-container'>
-<input name='post-instructions' type='radio' id='generic-post' checked>
-<input name='post-instructions' type='radio' id='fedora-post'>
-<input name='post-instructions' type='radio' id='debian-post'>
-<label class='menu-selector generic-post' for='generic-post'>Generic</label>
-<label class='menu-selector fedora-post' for='fedora-post'>Fedora/CentOS</label>
-<!-- <label class='menu-selector debian-post' for='debian-post'>Debian</label> -->
-
-<!-- ###### Post-installation instructions Generic ######################## -->
-<div class='post-instructions generic-post'>
-<p>There is nothing else to do. If you run into any issues, please see the <a href='{{site_root}}/getting-started/troubleshooting.html'>troubleshooting page</a>.</p>
-
-<p>If you want to see what Home Assistant can do, you can start the demo mode by running <code>hass --demo-mode</code>.</p>
-
-<p>In the future, if you want to update to the latest version, run <code>pip3 install --upgrade home-assistant</code>.</p>
-
-</div>
-<!-- ###### Post-installation instructions Fedora/CentOS ######################## -->
-<div class='post-instructions fedora-post'>
-<p>By default, the access to port 8123 is not allowed. If you want to allow other hosts in your local network access, open port 8123.</p>
-
+</ol></p>
+<p>When new stable versions are released, you can upgrade to newest version by typing the following into a console:</p>
 ```bash
-sudo firewall-cmd --permanent --add-port=8123/tcp
-sudo firewall-cmd --reload
+pip3 install --upgrade homeassistant
 ```
-<p>Home Assistant will serve its web interface on <a href='http://[IP address of the host]:8123'>http://[IP address of the host]:8123</a>.</p>
-
-<p>If you want that Home Assistant is lauched automatically, an extra step is needed to setup <code>systemd</code>. You need a service file to control Home Assistant with <code>systemd</code>. <!-- The <code>WorkingDirectory</code> and the <code>PYTHONPATH</code> must point to your clone git repository. --></p>
-
-<!-- WorkingDirectory=/home/fab/home-assistant/
-Environment="PYTHONPATH=/home/fab/home-assistant/" -->
-
-
-```bash
-su -c 'cat <<EOF >> /lib/systemd/system/home-assistant.service
-[Unit]
-Description=Home Assistant
-After=network.target
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/python3.4 -m homeassistant
-
-[Install]
-WantedBy=multi-user.target
-EOF'
-```
-
-<p>You need to reload <code>systemd</code> to make the daemon aware of the new configuration. Enable and launch Home Assistant after that.</p>
-
-```bash
-sudo systemctl --system daemon-reload
-sudo systemctl enable home-assistant
-sudo systemctl start home-assistant
-```
-
-<p>If everything went well, <code>sudo systemctl start home-assistant</code> should give you a positive feedback.</p>
-
-```bash
-$ sudo systemctl status home-assistant -l
-● home-assistant.service - Home Assistant
-   Loaded: loaded (/usr/lib/systemd/system/home-assistant.service; disabled; vendor preset: disabled)
-   Active: active (running) since Thu 2015-06-25 23:38:37 CEST; 3min 13s ago
- Main PID: 8557 (python3.4)
-   CGroup: /system.slice/home-assistant.service
-           └─8557 /usr/bin/python3.4 -m homeassistant
-[...]
-```
-
-<p>To get Home Assistant's logging output, simple use <code>journalctl</code>.</p>
-
-```bash
-sudo journalctl -f -u home-assistant
-```
-
-<p>In the future, if you want to update to the latest version, run <code>pip3 install --upgrade home-assistant</code>.</p>
-
-<p class='note'>
-Those instructions were written for Fedora 22 Server and Workstation. They may work for Cloud flavor as well but this was not tested.
-</p>
-
-
-</div>
-<!-- ##### Post-installation instructions Debian ######################### -->
-<div class='post-instructions debian-post'>
-
-<p>Coming soon...</p>
-
-
-
 </div>
 
+<div class='install-channels betachan'>
+<p>The beta channel will provide you with newer features sooner but at the risk of reduced stability. The brave and curious are welcomed here. To install, execute the following code in a console:</p>
+```bash
+pip3 install --pre homeassistant
+hass --open-ui
+```
+<p>Running these commands will:
+<ol>
+<li>Install Home Assistant</li>
+<li>Launch Home Assistant and serve web interface on <a href='http://localhost:8123'>http://localhost:8123</a></li>
+</ol></p>
+<p>When new a new release candidate, alpha, or beta version is released, you can upgrade to newest version by typing the following into a console:</p>
+```bash
+pip3 install --pre --upgrade homeassistant
+```
 </div>
 
-<br />
-<!-- ###### Post-installation END ######################## -->
-
-</div>
-
-<!-- ###### Docker START ######################## -->
-<div class='install-instructions docker'>
-<p>Installation with Docker is straightforward. Adjust the following command so that <code>/path/to/your/config/</code> points at the folder where you want to store your config and run it:</p>
-
+<div class='install-channels devchan'>
+<p>The development channel provides builds that are on the bleeding edge. This builds have not been fully tested or used. This is best for potential contributors and tinkerers. Subscribing to this channel is not for the faint of heart and requires significant knowledge of Git and Python.</p>
 ```bash
-docker run -d --name="home-assistant" -v /path/to/your/config:/config -v /etc/localtime:/etc/localtime:ro --net=host balloob/home-assistant
-```
-
-<p>This will launch Home Assistant and serve its web interface from port 8123 on your Docker host.</p>
-
-<p class='note'>
-When using boot2docker on OS X you are unable to map the local time to your Docker container. Replace <code>-v /etc/localtime:/etc/localtime:ro</code> with <code>-e "TZ=America/Los_Angeles"</code> (replacing America/Los_Angeles with <a href='http://en.wikipedia.org/wiki/List_of_tz_database_time_zones'>your timezone</a>)
-</p>
-
-</div>
-
-<!-- ###### Paspberry Pi START ######################## -->
-<div class='install-instructions raspberry'>
-
-<p>Home Assistant uses Python 3.4. This makes installation on a Raspberry Pi a bit more difficult as it is not available in the package repository. Please follow the following instructions to get it up and running.</p>
-
-<p><b>Step 1. Install pyenv</b></p>
-
-```bash
-curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
-```
-
-<p>After the installation is done, run:</p>
-
-```bash
-nano ~/.bashrc
-```
-
-<p>Then add these lines to the end of the file and save:</p>
-```
-export PATH="$HOME/.pyenv/bin:$PATH"
-eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"
-```
-
-<h5>Step 2. Install requirements</h5>
-
-```bash
-sudo apt-get install python3-dev
-sudo apt-get install libsqlite3-dev libreadline-dev libbz2-dev
-```
-
-<p>Log out and then back in so your bashrc is reloaded.</p>
-
-<p class='note'>
-NOTE: the rest of the commands are not being run as sudo and will install python etc under you user's home directory.
-</p>
-
-<p><b>Step 3. Install python 3.4.2 (this will take a few hours)</b></p>
-
-```bash
-pyenv install 3.4.2
-```
-
-<p><b>Step 4. Create Python Virtual Environment</b></p>
-```bash
-pyenv virtualenv 3.4.2 homeassistant
-```
-
-<p><b>Step 5. Set the virtual environment</b></p>
-```bash
+# Clone repo from git, you may want to use your own fork
+git clone --recursive https://github.com/balloob/home-assistant.git
 cd home-assistant
-pyenv local homeassistant
+# You may want to switch to a virtual environment here
+# Install Home Assistant in development mode
+python3 setup.py develop
+# Optionally pre-emptively install all possible dependencies
+pip3 install -r requirements_all.txt
 ```
-
-<p><b>Step 6. Install Home Assistant</b></p>
+<p>To keep up-to-date with the development channel, you will have to fetch and merge from the dev branch in the head repository. Be careful when doing this.</p>
 ```bash
-pip3 install homeassistant
+git fetch balloob
+git merge remotes/balloob/dev
 ```
-
-<p><b>Step 7. Start it up</b></p>
-```bash
-hass
-```
-
-<p>It will be up and running on port 8123</p>
-
-<p>In the future, if you want to update to the latest version, run <code>pip3 install --upgrade home-assistant</code>.</p>
-
 </div>
 
-</div>
+</div><!-- install-channels-container -->
+
+
+<h3>Troubleshooting</h3>
+
+<p>If you run into any issues, please see the <a href='{{site_root}}/getting-started/troubleshooting.html'>troubleshooting page</a>. It contains solutions to many of the common issues.</p>
+
+<p>For additional help, in addition to this site, there are three sources:
+<ul>
+<li><a href="https://gitter.im/balloob/home-assistant" target="_blank">Gitter Chatroom</a> for general Home Assistant discussions and questions.</li>
+<li><a href="https://groups.google.com/forum/#!forum/home-assistant-dev" target="_blank">Development Mailing List</a> for development related questions and discussing new features.</li>
+<li><a href="https://github.com/balloob/home-assistant" target="_blank">GitHub Page</a> for issue reporting.</li>
+</ul>
+</p>
+
+
+<h3>What's Next</h3>
+<p>If you want to see what Home Assistant can do, you can start the demo mode by running <code>hass --demo-mode</code>. Home Assistant has a few other command line flags that can be displayed by running <code>hass --help</code>.</p>
+<p>From here you may now start configuring Home Assistant to your liking. For more advanced users, the <a href='{{site_root}}/getting-started/advanced.html'>advanced configuration page</a> contains brief tutorials on creating more advanced installations such as installing daemons and using Docker.</p>
+
 
 ###[Next step: configuring Home Assistant &raquo;](/getting-started/configuration.html)
-

--- a/source/getting-started/troubleshooting.markdown
+++ b/source/getting-started/troubleshooting.markdown
@@ -17,7 +17,7 @@ This utility should have been installed as part of the Python 3.4 installation. 
 is installed by running `python3 --version`. If it is not installed,
 [download it here](https://www.python.org/getit/).
 
-If you are to succesfully run `python3 --version` but not `pip3`, run the following command instead
+If you are able to successfully run `python3 --version` but not `pip3`, run the following command instead
 to install Home Assistant: `python3 -m pip install homeassistant`.
 
 **No module named pip**<br>
@@ -27,8 +27,27 @@ by some distributions. If you are unable to run `python3 -m pip --version` you c
 `python3 get-pip.py`.
 
 **No access to the frontend**<br>
-In newer Linux distributions (at least Fedora 22/CentOS 7) the access to a host are very limited.
-This means that you can't access the Home Assistant Frontend that is running on a host in your
-network. Check the Post-installation section on the [Getting started](/getting-started/) page and
-follow the instruction that match your distribution to allow access to port 8123.
+In newer Linux distributions (at least Fedora 22/CentOS 7) the access to a host is very limited.
+This means that you can't access the Home Assistant Frontend that is running on a host outside of the host machine. Windows and OSX machines may also have issues with this.
 
+To fix this you will need to open your machine's firewall for TCP traffic over port 8123. The method for doing this will vary depending on your operating system and the firewall you have installed. Below are some suggestions to try. Google is your friend here.
+
+[Windows](http://windows.microsoft.com/en-us/windows/open-port-windows-firewall#1TC=windows-7) and [Mac OSX](https://support.apple.com/en-us/HT201642) have good instructions posted.
+
+For firewalld systems (Fedora, RHEL, etc.):
+```bash
+sudo firewall-cmd --permanent --add-port=8123/tcp
+sudo firewall-cmd --reload
+```
+
+For UFW systems (Ubuntu, Debian, Raspbian, etc.):
+```bash
+sudo ufw allow 8123/tcp
+```
+
+For iptables systems (usually the default):
+```bash
+iptables -I INPUT -p tcp --dport 8123 -j ACCEPT
+iptables-save > /etc/network/iptables.rules  # your rules may be saved elsewhere
+```
+###[&laquo; Back to Getting Started](/getting-started/index.html)


### PR DESCRIPTION
This commit is a large refactoring of the getting started page. This
version contains only the information necessary to get off the ground
and get your bearings. There is also one consistent flow on information
rather than a spaghetti flow. Advanced installation details have been
moved to their own page (Docker and daemons). Details about opening
firewall ports have been expanded a bit and moved to the
troubleshooting page. The install instructions contain details about
all three install types (production, beta, and dev).

Let me know what you think. I think this is a bit easier to follow.