### PR TITLE
Information on RAM Tweaks for Raspberry Pi

### DIFF
--- a/source/components/index.markdown
+++ b/source/components/index.markdown
@@ -213,7 +213,7 @@ Entities are things that you want to observe within Home Assistant. Support for 
 
 <tr>
   <td><a href='/components/media_player.cast.html'><img src='/images/supported_brands/google_cast.png' class='brand overview' /></a></td>
-  <td><a href='/components/media_player.cast.html'>Google Cast devices</a></td>
+  <td><a href='/components/media_player.cast.html'>Google Cast</a></td>
 </tr>
 
 <tr>
@@ -435,7 +435,7 @@ the manufacturers of these devices.
       <div class="grid">
         <div class="grid__item one-whole lap-two-thirds">
          <h2 class="title">Web services</h2>
-           <p>The web services displays data grabbed from an external source.</p>
+           <p>The web services displays data grabbed from an external source or interact with them.</p>
 
 <table>
 
@@ -456,7 +456,12 @@ the manufacturers of these devices.
 
 <tr>
   <td><a href='/components/sensor.swiss_public_transport.html'><img src='/images/supported_brands/appointment-new.png' class='brand overview' /></a></td>
-  <td><a href='/components/sensor.swiss_public_transport.html'>Swiss Public Transport</a> displays  Swiss timetable data for traveling.</td>
+  <td><a href='/components/sensor.swiss_public_transport.html'>Swiss Public Transport</a> displays Swiss timetable data for traveling.</td>
+</tr>
+
+<tr>
+  <td><a href='/components/ifttt.html'><img src='/images/supported_brands/ifttt.png' class='brand overview' /></a></td>
+  <td><a href='/components/ifttt.html'>IFTTT</a> allows the triggering of recipes.</td>
 </tr>
 
 </table>

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -284,6 +284,18 @@ hass
 
 <p>In the future, if you want to update to the latest version, run <code>pip3 install --upgrade home-assistant</code>.</p>
 
+<p><b>Additional tweaks for the Raspberry Pi</b></p>
+<p>If you are going to run the Pi in text only mode or headless, you can run the following command:</p>
+```bash
+sudo raspi-config
+```
+
+<p>Select option 8 : `Advanced Options` </br>
+and then `Memory Split` </br>
+Give the GPU (Graphics Processor) the least amount of memory (16). </br>
+
+This will give the lion's share of the memory to the core functions.</p>
+
 </div>
 
 </div>

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -299,7 +299,7 @@ This will give the lion's share of the memory to the core functions.</p>
 <p> If you would like to run `hass` as a background process on the Raspberry Pi, you can run the following command:</p>
 
 ```bash
-nohup myscript.sh </dev/null 1>&2&> nohup.log &
+nohup hass </dev/null 1>&2&> nohup.log &
 ```
 <p> This will launch Home Assistant as a background process and continue to run even after disconnecting from a terminal session.</p>
 <p> You can shut down Home Assistant using the Developer services on the Web Interface.</p>

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -307,7 +307,7 @@ nohup myscript.sh </dev/null 1>&2&> nohup.log &
 ![Shutdown Home Assistant](http://i.imgur.com/QGIrkgJ.png)
 
 <p class='note'>
-NOTE: Make sure your Home Assistant installation is working correctly before trying to launch as a background process.  You can use `tail -f ~/.homeassistant/home-assistant.log` to review any errors.  You can press CTRL-C to exit the log.
+NOTE: Make sure your Home Assistant installation is working correctly before trying to launch as a background process.  You can use `tail -f ~/.homeassistant/home-assistant.log` to review any errors or `tail -f ~/nohup.log` to view a more verbose version.  You can press CTRL-C to exit either of the logs.
 </p>
 
 </div>


### PR DESCRIPTION
Added additional information on using raspi-config to set memory split to 16 for headless and text only operations.