### PR TITLE
fix a couple of typo in proliphix docs

### DIFF
--- a/source/_components/thermostat.proliphix.markdown
+++ b/source/_components/thermostat.proliphix.markdown
@@ -22,7 +22,7 @@ To set it up, add the following information to your `configuration.yaml` file:
 
 ```yaml
 thermostat:
-  platform: homematic
+  platform: proliphix
   host: IP_ADDRESS
   username: YOUR_USERNAME
   password: YOUR_PASSWORD
@@ -30,9 +30,11 @@ thermostat:
 
 Configuration variables:
 
-- **host** (*Required*: Adress of your thermostat, eg. 192.168.1.32
+- **host** (*Required*): Adress of your thermostat, eg. 192.168.1.32
 - **username** (*Required*): Username for the thermostat.
 - **password** (*Required*): Password for the thermostat.
 
-The Proliphix NT Thermostat series are ethernet connected thermostats. They have a local HTTP interface that is based on get/set of OID values. A complete collection of the API is available in this [API documentation](https://github.com/sdague/thermostat.rb/blob/master/docs/PDP_API_R1_11.pdf).
-
+The Proliphix NT Thermostat series are ethernet connected
+thermostats. They have a local HTTP interface that is based on get/set
+of OID values. A complete collection of the API is available in this
+[API documentation](https://github.com/sdague/thermostat.rb/blob/master/docs/PDP_API_R1_11.pdf).


### PR DESCRIPTION
the example used the wrong symbol for ``platform``

there was a missing parren on the parameters

wrapped one of the larger paragraphs just to make it simple to
read/edit in raw format.