### PR TITLE
Add documentation about SCSGate

### DIFF
--- a/source/_components/light.scsgate.markdown
+++ b/source/_components/light.scsgate.markdown
@@ -1,0 +1,29 @@
+---
+layout: component
+title: "SCSGate light"
+description: "Instructions how to integrate SCSGate lights into Home Assistant."
+date: 2016-01-31 19:30
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Light
+---
+
+The SCSGate device can control lights of the BTicino MyHome system.
+
+To enable SCSGate lights in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+light:
+  platform: scsgate
+  devices:
+    living_room:
+      name: Living Room
+      scs_id: XXXXX
+```
+
+Configuration variables:
+
+- **devices** (*Required*): A list of devices with their name to use in the frontend.

--- a/source/_components/rollershutter.scsgate.markdown
+++ b/source/_components/rollershutter.scsgate.markdown
@@ -1,0 +1,30 @@
+---
+layout: component
+title: "SCSGate Rollershutter"
+description: "Instructions how to integrate SCSGate motorized devices into Home Assistant."
+date: 2016-01-31 22:16
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Rollershutter
+---
+The SCSGate device can control motirized roller shutters connected to the BTicino MyHome system.
+
+To enable SCSGate roller shutters in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+rollershutter:
+  platform: scsgate
+  devices:
+    living_room:
+      name: Living Room
+      scs_id: XXXXX
+```
+
+Configuration variables:
+
+- **devices** (*Required*): A list of devices with their name to use in the frontend.
+
+**Known limitation:** it is not possible to know the current state of the roller shutter.

--- a/source/_components/scsgate.markdown
+++ b/source/_components/scsgate.markdown
@@ -1,0 +1,33 @@
+---
+layout: component
+title: "SCSGate"
+description: "Instructions how to integrate SCSGate into Home Assistant."
+date: 2016-01-31 19:20
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Hub
+---
+
+The SCSGate component support the [SCSGate](https://translate.google.com/translate?hl=en&sl=it&tl=en&u=http%3A%2F%2Fguidopic.altervista.org%2Feibscsgt%2Finterface.html) device. This a homebrew device allows to interact with the MyHome system from BTicino/Legrande.
+
+To enable SCSGate in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+scsgate:
+  device: PATH_TO_DEVICE
+```
+
+Configuration variables:
+
+- **device** (*Required*): The path to your device, e.g. `/dev/ttyACM0`
+
+### How to find the scs_id for your devices
+
+The SCSGate component relies on the [scsgate](https://github.com/flavio/scsgate) python module.
+
+This module provides also a command line tool called `scs-monitor`. This program can be used to find the IDs of your lights, switches and roller shutters and produce the YAML snippet to insert into your `configuration.yaml` file.
+
+For more information checkout [this](http://scsgate.readthedocs.org/en/latest/?badge=latest#creation-of-a-home-assistant-configuration-file) section of `scsgate`'s documentation.

--- a/source/_components/switch.scsgate.markdown
+++ b/source/_components/switch.scsgate.markdown
@@ -1,0 +1,29 @@
+---
+layout: component
+title: "SCSGate switch"
+description: "Instructions how to integrate SCSGate switches into Home Assistant."
+date: 2016-01-31 22:15
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Switch
+---
+
+The SCSGate device can control switches of the BTicino MyHome system.
+
+To enable SCSGate switches in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  platform: scsgate
+  devices:
+    living_room:
+      name: Living Room
+      scs_id: XXXXX
+```
+
+Configuration variables:
+
+- **devices** (*Required*): A list of devices with their name to use in the frontend.


### PR DESCRIPTION
This adds the documentation about the SCSGate code that has been merged with [this](https://github.com/balloob/home-assistant/pull/1056) pull request.

There's one thing I don't understand, only the main page about SCSGate and the one about the lights module show up. The others are not translated to html. Do you have any idea about why this is happening?