### PR TITLE
Add SSL parameters to Influx docs

### DIFF
--- a/source/_components/influxdb.markdown
+++ b/source/_components/influxdb.markdown
@@ -23,6 +23,8 @@ influxdb:
   database: DB_TO_STORE_EVENTS
   username: MY_USERNAME
   password: MY_PASSWORD
+  ssl: true
+  verify_ssl: true
 ```
 
 Configuration variables:
@@ -32,4 +34,5 @@ Configuration variables:
 - **database** (*Optional*): Name of the database to use. Defaults to `home_assistant`. The database must already exist.
 - **username** (*Optional*): The username of the database user.
 - **password** (*Optional*): The password for the database user account.
-
+- **ssl** (*Optional*): Use https instead of http to connect. Defaults to false.
+- **verify_ssl** (*Optional*): Verify SSL certificate for https request. Defaults to false.


### PR DESCRIPTION
Add documentation for https://github.com/balloob/home-assistant/pull/1117, which adds the `ssl` and `verify_ssl` parameters to Influx platform.