### PR TITLE
Fix git URLs and order of execution in developer guide bash commands.

### DIFF
--- a/source/developers/index.markdown
+++ b/source/developers/index.markdown
@@ -22,9 +22,9 @@ Home Assistant is open-source and MIT licensed. The source can be found here:
 You will need to setup a development environment if you want to start developing a new feature or component for Home Assistant. Please follow these steps to perform it. Visit the [the Home Assistant repository](https://github.com/balloob/home-assistant) first and click fork in the top right.
 
 ```bash
-$ git clone https://github.com/your_github_username/home-assistant.git
-$ git remote add upstream git@github.com:balloob/home-assistant.git
+$ git clone git@github.com:your_github_username/home-assistant.git
 $ cd home-assistant
+$ git remote add upstream https://github.com/balloob/home-assistant.git
 $ script/setup
 ```
 


### PR DESCRIPTION
You'll want to use the SSH URL for your own repo and the HTTPS one for the upstream. Also, `cd` into the repo before trying to add upstream.

I don't know whether this should be pointed at `master` or `next` since it's a bugfix. I used the workflow of "edit this page on github" which defaulted to `master`.