### PR TITLE
fixed wink hub links

### DIFF
--- a/source/_components/garage_door.wink.markdown
+++ b/source/_components/garage_door.wink.markdown
@@ -14,5 +14,5 @@ ha_category: Garage Door
 
 The Wink garage door platform allows you to control your [Wink](http://www.wink.com/) enabled garage door.
 
-The requirement is that you have setup your [Wink hub](/components/light.wink/).
+The requirement is that you have setup your [Wink hub](/components/wink/).
 

--- a/source/_components/light.wink.markdown
+++ b/source/_components/light.wink.markdown
@@ -14,4 +14,4 @@ ha_category: Light
 
 The wink light platform allows you to use your [Wink](http://www.wink.com/) lights.
 
-The requirement is that you have setup your [Wink hub](/components/light.wink/).
+The requirement is that you have setup your [Wink hub](/components/wink/).

--- a/source/_components/sensor.wink.markdown
+++ b/source/_components/sensor.wink.markdown
@@ -14,5 +14,5 @@ ha_category: Sensor
 
 The Wink sensor platform allows you to get data from your [Wink](http://www.wink.com/) sensors.
 
-The requirement is that you have setup your [Wink hub](/components/light.wink/).
+The requirement is that you have setup your [Wink hub](/components/wink/).
 

--- a/source/_components/switch.wink.markdown
+++ b/source/_components/switch.wink.markdown
@@ -14,5 +14,5 @@ ha_category: Switch
 
 The Wink switch platform allows you to control your [Wink](http://www.wink.com/) switches.
 
-The requirement is that you have setup your [Wink hub](/components/light.wink/).
+The requirement is that you have setup your [Wink hub](/components/wink/).
 


### PR DESCRIPTION
Noticed some links pointing to the wrong page while gathering inspiration for the Verisure documentation