### PR TITLE
Allow preview with a different bind address

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,13 +77,14 @@ task :watch do
 end
 
 desc "preview the site in a web browser"
-task :preview do
+task :preview, :listen do |t, args|
+  listen_addr = args[:listen] || '127.0.0.1'
   raise "### You haven't set anything up yet. First run `rake install` to set up an Octopress theme." unless File.directory?(source_dir)
   puts "Starting to watch source with Jekyll and Compass. Starting Rack on port #{server_port}"
   system "compass compile --css-dir #{source_dir}/stylesheets" unless File.exist?("#{source_dir}/stylesheets/screen.css")
   jekyllPid = Process.spawn({"OCTOPRESS_ENV"=>"preview"}, "jekyll build --watch --incremental")
   compassPid = Process.spawn("compass watch")
-  rackupPid = Process.spawn("rackup --port #{server_port}")
+  rackupPid = Process.spawn("rackup --port #{server_port} --host #{listen_addr}")
 
   trap("INT") {
     [jekyllPid, compassPid, rackupPid].each { |pid| Process.kill(9, pid) rescue Errno::ESRCH }


### PR DESCRIPTION
This makes the Rakefile preview task honor a listen address instead of
always defaulting to 127.0.0.1. This makes it easier to run the preview
on a machine other than where you have a web browser running.

To use:

  rake preview[0.0.0.0]