### PR TITLE
Update FRITZ!Box install to include python3-lxml

### DIFF
--- a/source/_components/device_tracker.fritz.markdown
+++ b/source/_components/device_tracker.fritz.markdown
@@ -15,7 +15,7 @@ ha_category: Presence Detection
 The `fritz` platform offers presence detection by looking at connected devices to a [AVM Fritz!Box](http://avm.de/produkte/fritzbox/) based router.
 
 <p class='note warning'>
-It might be necessary to install additional packages: <code>$ sudo apt-get install libxslt-dev libxml2-dev</code>
+It might be necessary to install additional packages: <code>$ sudo apt-get install libxslt-dev libxml2-dev python3-lxml</code>
 </p>
 
 To use an Fritz!Box router in your installation, add the following to your `configuration.yaml` file:


### PR DESCRIPTION
Without it fritzconnection might not be able to install correctly on low-end machines (e.g. Raspberry Pi) due to running out of resources while trying to compile lxml via pip3.