### PR TITLE
Binary template docs and an extra example

### DIFF
--- a/source/_components/binary_sensor.template.markdown
+++ b/source/_components/binary_sensor.template.markdown
@@ -1,0 +1,51 @@
+---
+layout: page
+title: "Template Binary Sensor"
+description: "Instructions how to integrate Template binary sensors into Home Assistant."
+date: 2016-02-25 15:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Binary Sensor
+---
+
+The `template` platform supports sensors which breaks out the state and `state_attributes` from other entities.
+
+To enable Template sensors in your installation, add the following to your `configuration.yaml` file:
+
+```yaml
+# Example configuration.yaml entry
+binary_sensor:
+  platform: template
+  sensors:
+    sun_up:
+      value_template: {% raw %}'{{ states.sun.sun.attributes.elevation > 0}}'{% endraw %}
+      friendly_name: 'Sun is up'
+```
+
+Configuration variables:
+
+- **sensors** array (*Required*): List of your sensors.
+  - **friendly_name** (*Optional*): Name to use in the Frontend.
+  - **sensor_class** (*Optional*): Defines the class of the sensor (motion, heat, moisture, etc)
+  - **value_template** (*Optional*): Defines a [template](/getting-started/templating/) to extract a value from the payload.
+
+
+## {% linkable_title Examples %}
+
+In this section you find some real life examples of how to use this sensor.
+
+### {% linkable_title Sensor threshold %}
+
+This example indicates true if a sensor is above a given threshold. Assuming a sensor of `furnace` that provides a current reading for the fan motor, we can determine if the furnace is running by checking that it is over some threshold:
+
+```yaml
+sensor:
+  platform: template
+  sensors:
+      furnace_on:
+        value_template: {{ states.sensor.furnace.state > 2.5 }}
+        friendly_name: 'Furnace Running
+        sensor_class: heat
+```

--- a/source/_cookbook/notify_if_over_threshold.markdown
+++ b/source/_cookbook/notify_if_over_threshold.markdown
@@ -1,0 +1,48 @@
+---
+layout: page
+title: "Send notification based on sensor"
+description: "Basic example of how to send a templated notification if a sensor is over a given threshold"
+date: 2016-02-25 15:00
+sidebar: true
+comments: false
+sharing: true
+footer: true
+ha_category: Automation Examples
+---
+
+The following example sends a notification via pushbullet if a sensor is over a critical value:
+
+```yaml
+
+notify me:
+  platform: pushbullet
+  api_key: "API_KEY_HERE"
+  name: mypushbullet
+
+automation:
+  - alias: FanOn
+    trigger:
+      platform: numeric_state
+      entity_id: sensor.furnace
+      above: 2
+    action:
+      service: notify.mypushbullet
+      data:
+        title: "Furnace fan is running"
+        message: "Fan running because current is {% raw %}{{ states.sensor.furnace.state }}{% endraw %} amps"
+```
+
+If you also want a notification when it drops back down below that limit, you could add this as well:
+
+```yaml
+  - alias: FanOff
+    trigger:
+      platform: numeric_state
+      entity_id: sensor.furnace
+      below: 2
+    action:
+      service: notify.mypushbullet
+      data:
+        title: "Furnace fan is stopped"
+        message: "Fan stopped because current is {% raw %}{{ states.sensor.furnace.state }}{% endraw %} amps"
+```


### PR DESCRIPTION
This adds docs for the template binary_sensor.

Also adds an automation example using a sensor and a notification, which seemed to be uncovered so far (took me a little fiddling to figure it out myself).