### PR TITLE
Fix mysensors binary sensor and some fixes

### DIFF
--- a/source/_components/binary_sensor.mysensors.markdown
+++ b/source/_components/binary_sensor.mysensors.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "MySensors Binary Sensor"
 description: "Instructions how to integrate MySensors binary sensors into Home Assistant."
-date: 2016-02-27 20:13 +0100
+date: 2016-02-28 01:20 +0100
 sidebar: true
 comments: false
 sharing: true
@@ -30,9 +30,9 @@ S_TYPE         | V_TYPE
 ---------------|----------------------------------
 S_SPRINKLER    | V_TRIPPED
 S_WATER_LEAK   | V_TRIPPED
-S_SOUND        | V_TRIPPED, V_LEVEL
-S_VIBRATION    | V_TRIPPED, V_LEVEL
-S_MOISTURE     | V_TRIPPED, V_LEVEL
+S_SOUND        | V_TRIPPED
+S_VIBRATION    | V_TRIPPED
+S_MOISTURE     | V_TRIPPED
 
 For more information, visit the [serial api] of MySensors.
 

--- a/source/_components/light.mysensors.markdown
+++ b/source/_components/light.mysensors.markdown
@@ -20,14 +20,12 @@ The following actuator types are supported:
 
 S_TYPE   | V_TYPE
 ---------|--------------
-S_LIGHT  | V_LIGHT
 S_DIMMER | V_DIMMER
 
 ##### MySensors version 1.5 and higher
 
 S_TYPE      | V_TYPE
 ------------|-------------
-S_LIGHT     | V_STATUS
 S_DIMMER    | V_PERCENTAGE
 S_RGB_LIGHT | V_RGB
 

--- a/source/_components/sensor.mysensors.markdown
+++ b/source/_components/sensor.mysensors.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "MySensors Sensor"
 description: "Instructions how to integrate MySensors sensors into Home Assistant."
-date: 2016-02-18 20:13 +0100
+date: 2016-02-28 01:20 +0100
 sidebar: true
 comments: false
 sharing: true
@@ -20,9 +20,6 @@ The following sensor types are supported:
 
 S_TYPE             | V_TYPE
 -------------------|---------------------------------------
-S_DOOR             | V_TRIPPED
-S_MOTION           | V_TRIPPED
-S_SMOKE            | V_TRIPPED
 S_TEMP             | V_TEMP
 S_HUM              | V_HUM
 S_BARO             | V_PRESSURE, V_FORECAST
@@ -46,11 +43,9 @@ S_TYPE         | V_TYPE
 ---------------|----------------------------------
 S_COLOR_SENSOR | V_RGB
 S_MULTIMETER   | V_VOLTAGE, V_CURRENT, V_IMPEDANCE
-S_SPRINKLER    | V_TRIPPED
-S_WATER_LEAK   | V_TRIPPED
-S_SOUND        | V_TRIPPED, V_LEVEL
-S_VIBRATION    | V_TRIPPED, V_LEVEL
-S_MOISTURE     | V_TRIPPED, V_LEVEL
+S_SOUND        | V_LEVEL
+S_VIBRATION    | V_LEVEL
+S_MOISTURE     | V_LEVEL
 S_LIGHT_LEVEL  | V_LEVEL
 S_AIR_QUALITY  | V_LEVEL (replaces V_DUST_LEVEL)
 S_DUST         | V_LEVEL (replaces V_DUST_LEVEL)

--- a/source/_components/switch.mysensors.markdown
+++ b/source/_components/switch.mysensors.markdown
@@ -2,7 +2,7 @@
 layout: page
 title: "MySensors Switch"
 description: "Instructions how to integrate MySensors switches into Home Assistant."
-date: 2016-02-15 20:49 +0100
+date: 2016-02-28 01:20 +0100
 sidebar: true
 comments: false
 sharing: true
@@ -23,12 +23,14 @@ S_TYPE   | V_TYPE
 S_DOOR   | V_ARMED
 S_MOTION | V_ARMED
 S_SMOKE  | V_ARMED
+S_LIGHT  | V_LIGHT
 S_LOCK   | V_LOCK_STATUS
 
 ##### MySensors version 1.5 and higher
 
 S_TYPE       | V_TYPE
 -------------|------------------
+S_LIGHT      | V_STATUS
 S_BINARY     | V_STATUS, V_LIGHT
 S_SPRINKLER  | V_STATUS
 S_WATER_LEAK | V_ARMED


### PR DESCRIPTION
* Fix binary sensor page. Move door, motion, smoke, and only part of
  sprinkler, leak, sound, vibration and moisture sensors to binary
  sensor from sensor page.
* Move back S_LIGHT to switch page from light page.