### PR TITLE
Added NetAtmo rainmeter support

### DIFF
--- a/source/_components/sensor.netatmo.markdown
+++ b/source/_components/sensor.netatmo.markdown
@@ -33,6 +33,10 @@ sensor:
       - co2
     module_name2:
       - temperature
+    rainmeter_name3:
+      - rain
+      - sum_rain_1
+      - sum_rain_24
 ```
 
 Configuration variables:
@@ -75,5 +79,5 @@ You have to provide these name in your Home Assistant configuration file.
 </p>
 
 <p class='note'>
-The Home Assistant NetAtmo platform has only be tested with the classic indoor and outdoor module. There is no support for the rainmeter and windmeter module at this time because developers does not own these modules.
+The Home Assistant NetAtmo platform has only be tested with the classic indoor, outdoor module and rainmeter. There is no support for the windmeter module at this time because developers does not own these modules.
 </p>


### PR DESCRIPTION
I've added the new parameters for the rainmeter in the example configuration and I've adjusted the "note" block.

This page should be go live, when the new home-assistant version is going live with the NetAtmo rain gauge support (see below commit).

https://github.com/balloob/home-assistant/commit/c14ca9983c66e6a2dd7bba7d42cf4a3a5e70d442