### PR TITLE
Missing disarmed state

### DIFF
--- a/source/_components/alarm_control_panel.mqtt.markdown
+++ b/source/_components/alarm_control_panel.mqtt.markdown
@@ -15,7 +15,7 @@ The `mqtt` alarm panel platform enables the possibility to control MQTT capable 
 
 The component will accept the following states from your Alarm Panel (in lower case):
 
-- 'armed'
+- 'disarmed'
 - 'armed_home'
 - 'armed_away'
 - 'pending'


### PR DESCRIPTION
No armed state in constants, but disarmed is missing here
https://github.com/balloob/home-assistant/blob/dev/homeassistant/const.py#L56