### PR TITLE
Add another reported/confirmed Mikrotik SNMP OID

### DIFF
--- a/source/_components/device_tracker.snmp.markdown
+++ b/source/_components/device_tracker.snmp.markdown
@@ -19,7 +19,8 @@ This device tracker needs SNMP to be enabled on the router.
 </p>
 
 OID examples:
-- Microtik: 1.3.6.1.4.1.14988.1.1.1.2.1.1 (confirmed)
+- Mikrotik: 1.3.6.1.4.1.14988.1.1.1.2.1.1 (confirmed, unknown RouterOS version/model)
+- Mikrotik: 1.3.6.1.2.1.4.22.1.2 (confirmed, RouterOS 6.x on RB2011)
 - Aruba: 1.3.6.1.4.1.14823.2.3.3.1.2.4.1.2 (untested)
 - BiPAC 7800DXL: 1.3.6.1.2.1.17.7.1.2.2.1.1 (confirmed on firmware 2.32e)
 


### PR DESCRIPTION
This adds a new OID confirmed by a RouterOS 6.x user (the existing one
provides no results on that platform). Also correct misspelling in the
existing Mikrotik example.