### PR TITLE
Fix for #286

### DIFF
--- a/source/_components/media_player.firetv.markdown
+++ b/source/_components/media_player.firetv.markdown
@@ -26,6 +26,7 @@ Steps to configure your Amazon Fire TV stick with Home Assistant:
   - From the main (Launcher) screen, select Settings.
   - Select System > About > Network.
 - `pip install firetv[firetv-server]` into a Python 2.x environment
+  - If installed on Debian Jessie then the libssl-dev package is needed. Install it with `apt-get install libssl-dev`
 - `firetv-server -d <fire tv device IP>:5555`, background the process
 - Configure Home Assistant as follows:
 


### PR DESCRIPTION
Add missing prerequisite for Fire-tv component on Debian Jessie as suggested in #286