### PR TITLE
Update switch.command_line.markdown with example including statecmd

### DIFF
--- a/source/_components/switch.command_line.markdown
+++ b/source/_components/switch.command_line.markdown
@@ -87,3 +87,19 @@ switch:
       oncmd: "cvlc 1.mp3 vlc://quit &"
       offcmd: "pkill vlc"
 ```
+
+### {% linkable_title Control Foscam Motion Sensor %}
+
+This switch will control the motion sensor of Foscam Webcams which Support CGI Commands ([Source](http://www.ipcamcontrol.net/files/Foscam%20IPCamera%20CGI%20User%20Guide-V1.0.4.pdf)). This switch supports statecmd, which checks the current state of motion detection.
+```yaml
+# Example configuration.yaml entry
+# Replace admin and password with an "Admin" priviledged Foscam user
+# Replace ipaddress with the local IP address of your Foscam
+switch:
+  platform: command_line
+  switches:
+    foscam_motion:
+      oncmd: 'curl -k "https://ipaddress:443/cgi-bin/CGIProxy.fcgi?cmd=setMotionDetectConfig&isEnable=1&usr=admin&pwd=password"'
+      offcmd: 'curl -k "https://ipaddress:443/cgi-bin/CGIProxy.fcgi?cmd=setMotionDetectConfig&isEnable=0&usr=admin&pwd=password"'
+      statecmd: 'curl -k --silent "https://ipaddress:443/cgi-bin/CGIProxy.fcgi?cmd=getMotionDetectConfig&usr=admin&pwd=password" | grep -oP "(?<=isEnable>).*?(?=</isEnable>)"'
+      value_template: '{{ value == "1" }}'


### PR DESCRIPTION
Posted this example to Gitter: https://gitter.im/balloob/home-assistant?at=56e10e516fde057c26856411

None of the current examples for command_line switches show support for the statecmd along with value_template, so I think this might be a useful addition to the page. I'm happy to update the example with any other explanation