### PR TITLE
Make updating instructions more obvious

### DIFF
--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -285,7 +285,8 @@ For additional help, in addition to this site, there are four sources:
  - [GitHub Page](https://github.com/balloob/home-assistant/issues) for issue reporting.
 
 ### Updating
-To update Home Assistant to the latest release run: `pip3 install --upgrade homeassistant`
+To update Home Assistant to the latest release run: `pip3 install --upgrade homeassistant`  
+You then have to restart Home Assistant for the changes to take effect. If you have installed it as an autostarting daemon (see below), then run: `sudo service hass-daemon restart` 
 
 ### What's next
 If you want to have Home Assistant start on boot, autostart instructions can be found [here](/getting-started/autostart/).

--- a/source/getting-started/index.markdown
+++ b/source/getting-started/index.markdown
@@ -284,11 +284,12 @@ For additional help, in addition to this site, there are four sources:
  - [Gitter Chatroom](https://gitter.im/balloob/home-assistant) for general Home Assistant discussions and questions.
  - [GitHub Page](https://github.com/balloob/home-assistant/issues) for issue reporting.
 
+### Updating
+To update Home Assistant to the latest release run: `pip3 install --upgrade homeassistant`
+
 ### What's next
 If you want to have Home Assistant start on boot, autostart instructions can be found [here](/getting-started/autostart/).
 
 To see what Home Assistant can do, launch demo mode: `hass --demo-mode` or visit the [demo page](/demo).
-
-To update Home Assistant to the latest release run: `pip3 install --upgrade homeassistant`
 
 ### [Next step: Configuring Home Assistant &raquo;](/getting-started/configuration/)


### PR DESCRIPTION
Make updating instructions more obvious.
Could I also suggest that the "Update Available" option that I see on my States page links directly to this fragment? Currently it just links to the main page and I have to scroll through to figure out how to update.
Thanks