### PR TITLE
removed http from ip address example.

### DIFF
--- a/source/_components/scene.hunterdouglas_powerview.markdown
+++ b/source/_components/scene.hunterdouglas_powerview.markdown
@@ -24,4 +24,4 @@ scene:
 
 Configuration variables:
 
-- **address** (*Required*): IP address of the PowerView Hub, eg. http://192.168.1.10.
+- **address** (*Required*): IP address of the PowerView Hub, eg. 192.168.1.10.


### PR DESCRIPTION
adding "http://" to the config would result in an error.