### PR TITLE
Clarified and added detail for devices, customizations and groups

### DIFF
--- a/source/_components/group.markdown
+++ b/source/_components/group.markdown
@@ -15,10 +15,11 @@ Groups allow the user to combine multiple entities into one. A group can be prom
 
 Check the **Set State** page from the **Developer Tools** and browse the **Current entities:** listing for all available entities.
 
+By default, every group appears in the HOME tab. If you name a group `default_view` it will REPLACE the contents of the HOME tab so you can customize it as you wish.
+
 ```yaml
 # Example configuration.yaml entry
 group:
-  # If you name an entry default_view it will REPLACE the contents of the "Home" tab
   default_view:
     view: yes
     entities:
@@ -42,9 +43,9 @@ group:
 
 Configuration variables:
 
+- **view** (*Optional*): If yes then the entry will be shown as a view (tab).
 - **name** (*Optional*): Name of the group.
-- **icon** (*Optional*): An optional icon to show in the Frontend.
-- **view** (*Optional*): If yes then the entry will be shown as a view.
+- **icon** (*Optional*): If you specify an icon it will show in the frontend instead of the name. This only applies to views; regular groups can't have icons.
 - **entities** array or comma delimited string (*Required*): List of entites to group.
 
 <p class='img'>
@@ -52,14 +53,24 @@ Configuration variables:
 Example of groups shown as views in the frontend.
 </p>
 
-If all entities are switches or lights they can be controlled as one with a switch at the top of the card. Grouped states should share the same type of states (ON/OFF or HOME/NOT_HOME).
+If all entities in a group are switches or lights then Home Assistant adds a switch at the top of the card that turns them all on/off at once.
+
+You can create views (tabs) that contain other groups.  
+Notice in the example below that in order to refer to the group "Living Room", you use `group.living_room` (lowercase and spaces replaced with underscores).
 
 ```yaml
-# Example configuration.yaml entry
-group:
-  living_room:
-    - light.bowl
-    - light.ceiling
-    - light.tv_back_light
-  children: device_tracker.child_1, device_tracker.child_2
-```
+# Example configuration.yaml entry that shows two groups, referred to in a view group (tab)
+  Living Room:
+    entities:
+      - light.light_family_1
+      - binary_sensor.motion_living
+  Bedroom:
+    entities:
+      - light.light_bedroom
+  Rooms:                                                                                                                                                       
+    view: yes                                                                                                                                                  
+    name: Rooms
+    entities:                                                                                                                                                  
+      - group.living_room                                                                                                                                      
+      - group.bedroom                                                                                                                                          
+``` 

--- a/source/_components/group.markdown
+++ b/source/_components/group.markdown
@@ -45,8 +45,8 @@ Configuration variables:
 
 - **view** (*Optional*): If yes then the entry will be shown as a view (tab).
 - **name** (*Optional*): Name of the group.
-- **icon** (*Optional*): If you specify an icon it will show in the frontend instead of the name. This only applies to views; regular groups can't have icons.
-- **entities** array or comma delimited string (*Required*): List of entites to group.
+- **icon** (*Optional*): If the group is a view, this icon will show at the top in the frontend instead of the name. If it's not a view, then the icon shows when this group is used in another group.
+- **entities** (*Required*): array or comma delimited string, list of entities to group.
 
 <p class='img'>
 <img src='/images/blog/2016-01-release-12/views.png'>
@@ -64,9 +64,7 @@ Notice in the example below that in order to refer to the group "Living Room", y
     entities:
       - light.light_family_1
       - binary_sensor.motion_living
-  Bedroom:
-    entities:
-      - light.light_bedroom
+  Bedroom: light.light_bedroom, switch.sleeping
   Rooms:                                                                                                                                                       
     view: yes                                                                                                                                                  
     name: Rooms

--- a/source/_components/sensor.speedtest.markdown
+++ b/source/_components/sensor.speedtest.markdown
@@ -72,4 +72,4 @@ Configuration variables:
 - **hour** (*Optional*): Specify the hour(s) of the day to schedule the speedtest. Use a list for multiple entries. Default is None.
 - **day** (*Optional*): Specify the day(s) of the month to schedule the speedtest. Use a list for multiple entries. Default is None.
 
-This component uses [speetest-cli](https://github.com/sivel/speedtest-cli) to gather network performance data from Speedtest.net.  Please be aware of the potential [inconsistencies](https://github.com/sivel/speedtest-cli#inconsistency) that this component may display.
+This component uses [speedtest-cli](https://github.com/sivel/speedtest-cli) to gather network performance data from Speedtest.net.  Please be aware of the potential [inconsistencies](https://github.com/sivel/speedtest-cli#inconsistency) that this component may display.

--- a/source/getting-started/devices.markdown
+++ b/source/getting-started/devices.markdown
@@ -15,9 +15,8 @@ See the [components overview page](/components/) to find installation instructio
 
 Usually every entity needs its own entry in the `configuration.yaml` file. There are two styles for multiple entries:
 
-#### {% linkable_title Style 1 %}
-
-Collect every entity under the "parent". 
+#### {% linkable_title Style 1: Collect every entity under the "parent" %}
+ 
 
 ```yaml
 sensor:
@@ -34,9 +33,8 @@ switch:
   - platform: vera
 ```
 
-#### {% linkable_title Style 2 %}
+#### {% linkable_title Style 2: List each device separately %}
 
-List each device separately.  
 You need to append numbers or strings to differentiate the entries, as in the example below. The appended number or string must be unique.
 
 ```yaml

--- a/source/getting-started/devices.markdown
+++ b/source/getting-started/devices.markdown
@@ -13,7 +13,7 @@ Home Assistant will be able to automatically discover and configure any Google C
 
 See the [components overview page](/components/) to find installation instructions for your devices and services. If you can't find support for your favorite device or service, [consider adding support](/developers/add_new_platform/).
 
-Usually every entity needs its own entry in the `configuration.yaml` file. There are two kinds of style for multiple entries:
+Usually every entity needs its own entry in the `configuration.yaml` file. There are two styles for multiple entries:
 
 #### {% linkable_title Style 1 %}
 
@@ -36,21 +36,22 @@ switch:
 
 #### {% linkable_title Style 2 %}
 
-If you prefer to place your entries somewhere in the `configuration.yaml` file then you just choose this style. You need to append numbers (see example below) or strings (like `media_player livingroom:` or `media_player kitchen:`) to differentiate the entries. The appended number or string must be unique.
+List each device separately.  
+You need to append numbers or strings to differentiate the entries, as in the example below. The appended number or string must be unique.
 
 ```yaml
-media_player 1:
+media_player livingroom:
   platform: mpd
   server: IP_ADDRESS
 
-media_player 2:
+media_player kitchen:
   platform: plex
 
-camera:
+camera 1:
   platform: generic
 
-media_player 3:
-  platform: sonos
+camera 2:
+  platform: mjpeg
 ```
 
 <p class='note note'>
@@ -59,10 +60,11 @@ If your devices are not showing up in the frontend then check the entries in you
 
 ### {% linkable_title Grouping devices %}
 
-Once you have a bunch of devices set up, it is time to organize them. This can be done using groups. Each group exists of a name and a list of entity IDs. Entity IDs can be retrieved from the web interface by using the Set State page in the Developer Tools (icon in the middle).
+Once you have a bunch of devices set up, it is time to organize them into groups.  
+Each group exists of a name and a list of entity IDs. Entity IDs can be retrieved from the web interface by using the Set State page in the Developer Tools (second icon).
 
 ```yaml
-# Example configuration.yaml entry
+# Example configuration.yaml entry showing two styles
 group:
   living_room: light.table_lamp, switch.ac
   bedroom:
@@ -74,9 +76,11 @@ For more details please check the [Group](https://home-assistant.io/components/g
 
 ### {% linkable_title Customizing devices and services %}
 
-By default, all of your devices will be visible and have a default icon determined by their domain. You may find it desireable to customize the look and feel of your front page by altering some of these parameters. This can be done by adding the following configuration to the `homeassistant:` section.
+By default, all of your devices will be visible and have a default icon determined by their domain. You can customize the look and feel of your front page by altering some of these parameters. This can be done by adding the following configuration inside the `homeassistant:` section.
 
-`entity_pictures`, badges, `device_tracker` pictures, etc. can either be a URL or `/local/file.jpg`, which points to directory `www` in the HASS configuration directory.
+`entity_picture`s, badges, `device_tracker` pictures, etc. can either be external URLs or like `/local/filename.jpg`, where `/local` points to the directory `www` in the HASS configuration directory. You may have to create the `www` directory yourself as it is not made automatically.
+
+You can also use `icon` and refer to any icon from [MaterialDesignIcons.com](http://MaterialDesignIcons.com).
 
 ```yaml
 # Example configuration.yaml entry
@@ -85,10 +89,13 @@ homeassistant:
   # Add this to your existing configuration
   # Only the `entity_id` is required.  All other options are optional.
   customize:
-    some.entity_id:
+    thermostat.family_roomfamily_room:
       hidden: true
-      entity_picture: http://placehold.it/200x200
-      friendly_name: My better name
+      entity_picture: https://dl.dropboxusercontent.com/u/12345/images/nest.jpg
+      friendly_name: Nest
+    switch.wemo_switch_1:
+      friendly_name: Kitchen kettle
+      icon: mdi:kettle
 ```
 
 ### [Next step: Setting up presence detection &raquo;](/getting-started/presence-detection/)


### PR DESCRIPTION
added example of group views that refer to other groups.

I've been going through the docs and using the Gitter chat to understand them, so I'm updating the docs to be clearer. 
(I think more examples of configuration files with images to match would be *really* helpful.)