### PR TITLE
Lots of typo corrections, added some useful examples. 

### DIFF
--- a/source/_components/automation.markdown
+++ b/source/_components/automation.markdown
@@ -15,6 +15,10 @@ This page will go into more detail about the various options the `automation` co
 
 A configuration section of an automation requires a `trigger` and an `action` section. `condition` and `condition_type` are optional. To keep this page compact, all following sections will not show the full configuration but only the relevant part.
 
+ - [Jump to conditions](#conditions)
+ - [Jump to actions](#actions)
+ - [Jump to troubleshooting](#troubleshooting)
+
 ```yaml
 # Example of entry in configuration.yaml
 automation:
@@ -68,10 +72,6 @@ automation:
     data:
       message: 'Paulus left the house'
 ```
-
- - [Jump to conditions](#conditions)
- - [Jump to actions](#actions)
- - [Jump to troubleshooting](#troubleshooting)
 
 ## {% linkable_title Triggers %}
 
@@ -207,9 +207,9 @@ automation:
 
 ## {% linkable_title Conditions %}
 
-Conditions are an optional part of an automation rule and be used to prevent an action from happening when triggered. Conditions look very familiar to triggers but are very different. A trigger will look at events happening at the system while a condition only looks at how the system looks right now. A trigger can observe that a switch is being turned on. A condition can only see if a switch is on or off.
+Conditions are an optional part of an automation rule and be used to prevent an action from happening when triggered. Conditions look very similar to triggers but are very different. A trigger will look at events happening in the system while a condition only looks at how the system looks right now. A trigger can observe that a switch is being turned on. A condition can only see if a switch is currently on or off.
 
-An automation rule can have mulitiple conditions. By default the action will only fire if all conditions pass. An optional key `condition_type: 'or'` can be set on the automation rule to fire action if any condition matches.  In the example below, the automation would trigger if the time is before 05:00 _OR_ after 20:00.
+An automation rule can have multiple conditions. By default the action will only fire if all conditions pass. An optional key `condition_type: 'or'` can be set on the automation rule to fire action if any condition matches.  In the example below, the automation would trigger if the time is before 05:00 _OR_ after 20:00.
 
 ```yaml
 automation:
@@ -230,18 +230,17 @@ automation:
 
 #### {% linkable_title Numeric state condition %}
 
-Attempts to parse the state of specified entity as a number and triggers if value is above and/or below a threshold.
+This type of condition attempts to parse the state of specified entity as a number and triggers if the value matches all of the above or below thresholds.  
+Either `above` or `below`, or both need to be specified. If both are used, the condition is true when the value is >= `before` *and** < `after`.  
+You can optionally use a `value_template` to make the value of the entity the same type of value as the condition. 
 
 ```yaml
 automation:
   condition:
     platform: numeric_state
     entity_id: sensor.temperature
-    # At least one of the following required
     above: 17
     below: 25
-    # Optional
-    value_template: '{% raw %}{{ state.attributes.battery }}{% endraw %}'
 ```
 
 #### {% linkable_title State condition %}
@@ -259,7 +258,6 @@ automation:
       hours: 1
       minutes: 10
       seconds: 5
-
 ```
 
 #### {% linkable_title Sun condition %}
@@ -277,7 +275,7 @@ automation:
 
 #### {% linkable_title Template condition %}
 
-The template condition will test if [given template][template] renders a value equal to true. This is achieved by having the template result in a true boolean expression or by having the template render 'true'.
+The template condition will test if the [given template][template] renders a value equal to true. This is achieved by having the template result in a true boolean expression or by having the template render 'true'.
 
 
 ```yaml
@@ -322,7 +320,7 @@ automation:
 
 ## {% linkable_title Actions %}
 
-When an automation rule fires, it calls a service. For this service you can specify an entity id it should apply to and optional service parameters (to specify for example the brightness).
+When an automation rule fires, it calls a service. For this service you can specify the entity_id that it should apply to and optional service parameters (to specify for example the brightness).
 
 ```yaml
 automation:
@@ -346,11 +344,11 @@ automation:
       message: Something just happened, better take a look!
 ```
 
-If you want to specify multiple services to be called or include a delay, have a look at the [script component](/components/script/). If you want to describe how certain entities should look, check out the [scene component](/components/scene/).
+If you want to specify multiple services to be called, or to include a delay, have a look at the [script component](/components/script/). If you want to describe the desired state of certain entities, check out the [scene component](/components/scene/).
 
 ## {% linkable_title Troubleshooting %}
 
-You can verify that your automation rules are being initialized correctly by watching both the realtime logs and also the logbook.  The realtime logs will show the rules being initialized (once for each trigger):
+You can verify that your automation rules are being initialized correctly by watching both the realtime logs (`homeassistant.log` in the configuration directory) and also the [Logbook](/components/logbook/). The realtime logs will show the rules being initialized (once for each trigger), example:
 
 ```plain
 INFO [homeassistant.components.automation] Initialized rule Rainy Day
@@ -359,7 +357,7 @@ INFO [homeassistant.components.automation] Initialized rule Rainy Day
 INFO [homeassistant.components.automation] Initialized rule Rain is over
 ```
 
-The Logbook component will show a line entry when an automation is triggered.  You can look at the previous entry to determine which trigger in the rule triggered the event.
+The Logbook component will show a line entry when an automation is triggered. You can look at the previous entry to determine which trigger in the rule triggered the event.
 
 ![Logbook example](/images/components/automation/logbook.png)
 

--- a/source/_components/conversation.markdown
+++ b/source/_components/conversation.markdown
@@ -12,7 +12,8 @@ ha_category: "Voice"
 ---
 
 
-The conversation component can process sentences into commands for Home Assistant. It is currently limited to parsing commands in the format `turn <Friendly Name> <on/off>`.
+The conversation component can process sentences into commands for Home Assistant. It is currently limited to parsing commands in the format `turn <Friendly Name> <on/off>`.  
+
 
 To enable the conversion option in your installation, add the following to your `configuration.yaml` file:
 
@@ -25,4 +26,8 @@ When this component is active and you are using a supported browser voice comman
 
 <p class='img'>
   <img src="/images/screenshots/voice-commands.png" />
+</p>
+
+<p class='note note'>
+Apple iPhones do not support this feature in any browser. 
 </p>

--- a/source/_components/http.markdown
+++ b/source/_components/http.markdown
@@ -33,8 +33,8 @@ Configuration variables:
 
 On top of the `http` component is a [REST API](/developers/rest_api/) and a [Python API](/developers/python_api/) available.
 
-The `http` platforms are not a real platform within the meaning of the terminology used around Home Assistant. Home Assistant's [REST API](/developers/rest_api/) is consuming and proceeding messages received over HTTP. 
+The `http` platforms are not real platforms within the meaning of the terminology used around Home Assistant. Home Assistant's [REST API](/developers/rest_api/) sends and receives messages over HTTP. 
 
 To use those kind of sensors in your installation no configuration in Home Assistant is needed. All configuration is done on the devices themselves. This means that you must be able to edit the target URL or endpoint and the payload. The entity will be created after the first message has arrived.
 
-All [requests](/developers/rest_api/#post-apistatesltentity_id) needs to be sent to the endpoint of the device and must be **POST**.
+All [requests](/developers/rest_api/#post-apistatesltentity_id) need to be sent to the endpoint of the device and must be **POST**.

--- a/source/_components/input_boolean.markdown
+++ b/source/_components/input_boolean.markdown
@@ -17,7 +17,7 @@ The `input_boolean` component allows the user to define boolean values that can 
 # Example configuration.yaml entry
 input_boolean:
   notify_home:
-    name: Notify when someome arrives home
+    name: Notify when someone arrives home
     initial: off
     icon: mdi:car
 ```
@@ -31,3 +31,22 @@ Configuration variables:
 
 Pick an icon that you can find on [materialdesignicons.com](https://materialdesignicons.com/) to use for your input and prefix the name with `mdi:`. For example `mdi:car`, `mdi:ambulance`, or  `mdi:motorbike`.
 
+Here's an example of an automation using the above input_boolean. This action will only occur if the switch is on.
+
+```yaml
+automation:
+  alias: Arriving home
+  trigger:
+    platform: state
+    entity_id: binary_sensor.motion_garage
+    to: 'on'
+  condition:
+    platform: state
+    entity_id: input_boolean.notify_home
+    state: 'on'
+  action:
+    service: notify.pushbullet
+    data:
+      title: ""
+      message: "Honey, I'm home!"
+```

--- a/source/_components/logger.markdown
+++ b/source/_components/logger.markdown
@@ -11,11 +11,11 @@ logo: home-assistant.png
 ha_category: "Other"
 ---
 
-The logger component lets one define the level of logging activities in Home Assistant.
+The logger component lets you define the level of logging activities in Home Assistant.
 
 To enable the logger in your installation, add the following to your `configuration.yaml` file:
 
-By default log all messages and ignore log event lowest than critical for custom omponents.
+By default log all messages and ignore events lower than critical for specified components.
 
 ```yaml
 # Example configuration.yaml entry
@@ -26,7 +26,7 @@ logger:
     homeassistant.components.camera: critical
 ```
 
-By default ignore all messages lowest than critical and log event for custom components.
+By default ignore all messages lower than critical and log event for specified components.
 
 ```yaml
 # Example configuration.yaml entry
@@ -41,7 +41,7 @@ logger:
 
 Possible log severities are:
 
-- citical
+- critical
 - fatal
 - error
 - warning

--- a/source/_components/scene.markdown
+++ b/source/_components/scene.markdown
@@ -11,9 +11,7 @@ logo: home-assistant.png
 ha_category: Organization
 ---
 
-A user can create scenes that capture the states you want certain entities to be. For example a scene can contain that light A should be turned on and light B should be bright red.
-
-Scenes can be activated using the service `scene.turn_on`.
+You can create scenes that capture the states you want certain entities to be. For example a scene can specify that light A should be turned on and light B should be bright red.
 
 ```yaml
 # Example configuration.yaml entry
@@ -32,4 +30,20 @@ scene:
         state: on
         brightness: 100
       light.ceiling: off
+```
+
+Scenes can be activated using the service `scene.turn_on` (there is no 'scene.turn_off' service).
+
+```yaml
+# Example automation
+...
+automation:
+  trigger:
+    platform: state
+    entity_id: device_tracker.sweetheart
+    from: 'not_home'
+    to: 'home'
+  action:                                                                                                
+    service: scene.turn_on                                                                               
+    entity_id: scene.romantic  
 ```

--- a/source/_components/sensor.tcp.markdown
+++ b/source/_components/sensor.tcp.markdown
@@ -68,7 +68,7 @@ sensor:
 
 ### {% linkable_title hddtemp %}
 
-The tool `hddtemp` collects the temperatur of your harddisks. 
+The tool `hddtemp` collects the temperature of your harddisks. 
 
 ```bash
 $ hddtemp

--- a/source/_components/weblink.markdown
+++ b/source/_components/weblink.markdown
@@ -11,9 +11,9 @@ logo:
 ha_category: Other
 ---
 
-The `weblinks` component allows you to display links in the Home Assistant frontend.
+The `weblink` component allows you to display links in the Home Assistant frontend.
 
-To use this component in your installation, add the following to your `configuration.yaml` file:
+To use this component in your installation, add something like the following to your `configuration.yaml` file:
 
 ```yaml
 # Example configuration.yaml entry

--- a/source/developers/architecture.markdown
+++ b/source/developers/architecture.markdown
@@ -28,7 +28,7 @@ The Home Assistant core is responsible for Home Control. It has four parts to ma
  * The **Event Bus** facilitates the firing and listening of events. This is the beating heart of Home Assistant.
  * The **State Machine** keeps track of the states of things. Fires a `state_changed` event when a state has been changed.
  * The **Service Registry** listens on the event bus for `call_service` events and allows other code to register services.
- * The **Timer** will send every 1 second a `time_changed` event on the event bus.
+ * The **Timer** will send a `time_changed` event every 1 second on the event bus.
 
 <p class='img'>
   <a href='/images/architecture/ha_architecture.png' name='architecture'>
@@ -37,15 +37,17 @@ The Home Assistant core is responsible for Home Control. It has four parts to ma
   Overview of the Home Assistant core architecture
 </p>
 
-Home Assistant can be extended by **components**. Each component is responsible for a specific domain within Home Assistant. Components can listen for- or trigger events, offer services and maintain states. Components are written in Python and can do all the goodness that Python has to offer. Out of the box, Home Assistant offers a bunch of [built-in components]({{site_root}}/components/).
+Home Assistant can be extended by **components**. Each component is responsible for a specific domain within Home Assistant. Components can listen for or trigger events, offer services and maintain states. Components are written in Python and can do all the goodness that Python has to offer. Out of the box, Home Assistant offers a bunch of [built-in components]({{site_root}}/components/).
 
-We can differentiate between two different types ofcomponents within Home Assistant.
+We can differentiate between two different types of components within Home Assistant.
 
 #### {% linkable_title Components that interact with an Internet of Things domain %}
 
-These components will track devices within a specific domain and exist of a core part and platform specific logic. These components make their information available via the State Machine and the Event Bus. The component will also register services in the Service Registry to expose control of the devices.
+These components will track devices within a specific domain and consist of a core part and platform-specific logic. These components make their information available via the State Machine and the Event Bus. The component will also register services in the Service Registry to expose control of the devices.
 
 For example, one of the built-in components is the `switch` component. This component is responsible for interaction with different types of switches.
+
+A platform provides support for a particular kind/brand of device. For example, a switch could use a WeMo or Orvibo platform, and a light component might interact with the Hue or LiFX platform.  
 
 If you are planning to add support for a new platform, please check out the [add new platform section]({{root_url}}/developers/add_new_platform/).
 
@@ -86,7 +88,7 @@ When we put all the different pieces of Home Assistant together we see that we m
   Overview of the full Home Assistant architecture with a couple of loaded components and platforms.
 </p>
 
-Component's platform logic uses 3rd party Python libraries to communicate with the devices. This is done so that we can leverage great device libraries that are out there in the Python community.
+The platform logic for components uses 3rd party Python libraries to communicate with the devices. This is done so that we can leverage great device libraries that are out there in the Python community.
 
 ## {% linkable_title Multiple connected instances %}
 
@@ -99,7 +101,7 @@ Home Assistant supports running multiple synchronized instances using a master-s
   Overview of the Home Assistant architecture for multiple devices.
 </p>
 
-A slave instance can be started with the following code and has the same support for components as a master-instance.
+A slave instance can be started with the following code and has the same support for components as a master instance.
 
 ```python
 import homeassistant.remote as remote
@@ -120,5 +122,5 @@ hass.block_till_stopped()
 ```
 
 <p class='note'>
-Because each slave maintains its own ServiceRegistry it is possible to have multiple slaves respond to one service call.
+Because each slave maintains its own Service Registry it is possible to have multiple slaves respond to one service call.
 </p>

--- a/source/developers/website.markdown
+++ b/source/developers/website.markdown
@@ -11,7 +11,7 @@ footer: true
 
 The home of Home Assistant is [https://home-assistant.io](https://home-assistant.io). This is the place where we provide documentation and additional details about Home Assistant for end users and developers. 
 
-home-assistant.io is using [Octopress](http://octopress.org/). To get more details, please checkout the [documentation](http://octopress.org/docs/). That means that creating a new page is simple. The pages are written in [markdown](http://daringfireball.net/projects/markdown/), you don't need to care about HTML or alike.
+home-assistant.io is using the [Octopress](http://octopress.org/) framework for [Jekyll](http://github.com/mojombo/jekyll). To get more details, please checkout the [documentation](http://octopress.org/docs/). That means that creating a new page is simple. The pages are written in [markdown](http://daringfireball.net/projects/markdown/), you don't need to care about HTML or alike.
 
 To work on the website the process is no different to working on Home Assistant itself.
 
@@ -24,13 +24,13 @@ To work on the website the process is no different to working on Home Assistant 
 For a platform page it would be the fastest way to make a copy of an existing page and edit it. The [component overview](/components/) is generated automatically, so there is no need to add a link to that your page.
 
 ### {% linkable_title Code %}
-To take advantage of the build-in features of Octopress to display code snipplets, just use the default markdown syntax. Please use `$` and `#` if it's a command and to differ from output.
+To take advantage of the built-in features of Octopress to display code snippets, just use the default markdown syntax. Please use `$` and `#` if it's a command and to differ from output.
 
 ```bash
 Here goes the code...
 ```
 
-If you want to display line numbers, add the following snipplets somewhere on your page. 
+If you want to display line numbers, add the following snippet somewhere on your page. 
 
 ```
 {::options coderay_line_numbers="table" /}
@@ -44,5 +44,5 @@ The images which are displayed on the pages are stored in various directories ac
 | screen shots | source/images/screenshots                     |
 | logos        | source/images/supported_brands                |
 
-Not everything (product, component, etc.) has a logo, to show something for internal parts of Home Assistant we are using the [Material Design Icons](https://materialdesignicons.com/). 
+Not everything (product, component, etc.) has a logo. To show something for internal parts of Home Assistant we are using the [Material Design Icons](https://materialdesignicons.com/). 
 

--- a/source/getting-started/configuration.markdown
+++ b/source/getting-started/configuration.markdown
@@ -11,11 +11,12 @@ footer: true
 
 Home Assistant will create a configuration folder when it is run for the first time. The location of the folder differs between operating systems: on OS X/Linux it's `~/.homeassistant` and on Windows it's `%APPDATA%/.homeassistant`. If you want to use a different folder for configuration, run `hass --config path/to/config`.
 
-Inside your configuration folder is the file `configuration.yaml`. This is the main file that contains which components will be loaded and what their configuration is. An example configuration file is located [here](https://github.com/balloob/home-assistant/blob/master/config/configuration.yaml.example).
+Inside your configuration folder is the file `configuration.yaml`. This is the main file that contains which components will be loaded and what their configuration is.  
+This file contains YAML code, which is explained briefly in [the configuration troubleshooting page](/getting-started/troubleshooting-configuration/). An example configuration file is located [here](https://github.com/balloob/home-assistant/blob/master/config/configuration.yaml.example).
 
 When launched for the first time, Home Assistant will write a default configuration enabling the web interface and device discovery. It can take up to a minute for your devices to be discovered and show up in the interface.
 
-If you are running into trouble while configuring Home Assistant, have a look at [the configuration troubleshoot page](/getting-started/troubleshooting-configuration/).
+If you run into trouble while configuring Home Assistant, have a look at [the configuration troubleshooting page](/getting-started/troubleshooting-configuration/).
 
 <p class='note'>
   You will have to restart Home Assistant for changes in <code>configuration.yaml</code> to take effect.
@@ -46,7 +47,7 @@ homeassistant:
 
 ### {% linkable_title Password protecting the web interface %}
 
-The first thing you want to add is a password for the web interface. Use your favourite text editor to open the file `/config/configuration.yaml` and add the following to the bottom:
+The first thing you want to add is a password for the web interface. Use your favourite text editor to open the file `/config/configuration.yaml` and add the following to the `http` section:
 
 ```yaml
 http:
@@ -59,12 +60,12 @@ _See the [HTTP component documentation][http] for more options like HTTPS encryp
 
 ### {% linkable_title Setting up your phone or tablet %}
 
-Home Assistant runs as a self hosted web application and contains support to be added to your homescreen. If you're on Android you can follow [the visual guide]({{site_root}}/getting-started/android/). For other devices, open Home Assistant on your mobile browser and tap on the add to homescreen option.
+Home Assistant runs as a self-hosted web application and contains support to be added to your home screen. If you're on Android you can follow [the visual guide]({{site_root}}/getting-started/android/). For other devices, open Home Assistant on your mobile browser and tap the add to home screen option.
 
 ### {% linkable_title Remote access %}
 
 To make Home Assistant accessible while away from home, you will have to setup port forwarding from your router to port 8123 on the computer that is hosting Home Assistant. Instructions on how to do this can be found by searching `<Router model> port forwarding instructions`.
 
-Some internet service providers will only offer dynamic IPs. This can cause you to be unable to access Home Assistant while away. You can solve this by using a free Dynamic DNS service like [DuckDNS](https://www.duckdns.org/).
+Some Internet service providers will only offer dynamic IPs. This can cause you to be unable to access Home Assistant while away. You can solve this by using a free Dynamic DNS service like [DuckDNS](https://www.duckdns.org/).
 
 ### [Next step: Setting up devices &raquo;](/getting-started/devices/)

--- a/source/getting-started/troubleshooting-configuration.markdown
+++ b/source/getting-started/troubleshooting-configuration.markdown
@@ -9,36 +9,37 @@ sharing: true
 footer: true
 ---
 
-It can happen that you run into trouble while configuring Home Assistant. A component is not showing up or is acting weird. This page will discuss a few of the most common problems.
+It can happen that you run into trouble while configuring Home Assistant. Perhaps a component is not showing up or is acting strangely. This page will discuss a few of the most common problems.
 
 Before we dive into common issues, make sure you know where your configuration directory is. Home Assistant will print out the configuration directory it is using when starting up.
 
-Whenever a component or configuration option results in a warning, it will be stored in `home-assistant.log`. This file is reset on start of Home Assistant.
+Whenever a component or configuration option results in a warning, it will be stored in `home-assistant.log` in the configuration directory. This file is reset on start of Home Assistant.
 
 ### {% linkable_title YAML %}
 
-Home Assistant uses the YAML syntax for configuration. YAML can be confusing at start but it is really powerful in allowing you to express complex configurations.
+Home Assistant uses the [YAML](http://yaml.org/) syntax for configuration. YAML can be confusing to start with but is really powerful in allowing you to express complex configurations.
 
-The basics of YAML are lists and lookup tables containing key-value pairs. Lists will have each item start with a `-` while lookup tables will have the format `key: value`. The last value for a key is used in case you specify a duplicate key.
+The basics of YAML are block collections and mappings containing key-value pairs. Collections will have each item start with a `-` while mappings will have the format `key: value`. The last value for a key is used in case you specify a duplicate key.  
+Note that the indentation is an important part of specifying relationships using YAML. 
 
 ```yaml
-# A list
+# A collection
 - hello
 - how
 - are
 - you
 
-# Lookup table
+# Lookup mapping
 beer: ice cold  # <-- will be ignored because key specified twice
 beer: warm
 wine: room temperature
 water: cold
 
-# Nesting tables
+# Nesting mappings (note the indentation)
 device_tracker:
   platform: mqtt
 
-# Nesting a list of tables in a table
+# Nesting a collection of mappings in a mapping
 sensor:
   - platform: mqtt
     state_topic: sensor/topic
@@ -46,10 +47,10 @@ sensor:
     state_topic: sensor2/topic
 ```
 
-Indentation is used to specify which objects are nested under one anohter. Getting the right indentation can be tricky if you're not using an editor with a fixed width font. Tabs are not allowed to be used for indentation. You can test your configuration using [online YAML parser](http://yaml-online-parser.appspot.com/) or [YAML Lint](http://www.yamllint.com/).
+Indentation is used to specify which objects are nested under one another. Getting the right indentation can be tricky if you're not using an editor with a fixed width font. Tabs are not allowed to be used for indentation.  
 
  - To learn more about the quirks of YAML, read [YAML IDIOSYNCRASIES](https://docs.saltstack.com/en/latest/topics/troubleshooting/yaml_idiosyncrasies.html) by SaltStack.
- - You can test your configuration using [this online YAML parser](http://yaml-online-parser.appspot.com/).
+ - You can test your configuration using [this online YAML parser](http://yaml-online-parser.appspot.com/) or [YAML Lint](http://www.yamllint.com/).
 
 ### {% linkable_title My component does not show up %}
 
@@ -57,19 +58,19 @@ When a component does not show up, many different things can be the case. Before
 
 #### {% linkable_title Problems with the configuration %}
 
-`configuration.yaml` does not allow multiple sections to have the same name. If you want a specific platform to be loaded twice, append a [number/string](/getting-started/devices/#style-2) to the name or use [this style](/getting-started/devices/#style-1).
+`configuration.yaml` does not allow multiple sections to have the same name. If you want a specific platform to be loaded twice, append a [number or string](/getting-started/devices/#style-2) to the name or nest them using [this style](/getting-started/devices/#style-1).
 
 ```yaml
 sensor:
   platform: forecast
-  [...]
+  ...
 
 sensor 2:
   platform: bitcoin
-  [...]
+  ...
 ```
 
-Another common problem is that a required configuration setting is missing. If this is the case, the component will report this to `home-assistant.log`. You can have a look at [the component page](/components/) for instructions how to setup the components.
+Another common problem is that a required configuration setting is missing. If this is the case, the component will report this to `home-assistant.log`. You can have a look at [the component page](/components/) for instructions on how to setup the components.
 
 If you find any errors or want to expand the documentation, please [let us know](https://github.com/balloob/home-assistant.io/issues).
 
@@ -77,7 +78,7 @@ If you find any errors or want to expand the documentation, please [let us know]
 
 Almost all components have external dependencies to communicate with your devices and services. Sometimes Home Assistant is unable to install the necessary dependencies. If this is the case, it should show up in `home-assistant.log`.
 
-First step is trying to restart Home Assistant and see if the problem persists. If it does, please [report it](https://github.com/balloob/home-assistant/issues) so we can investigate what is going on.
+The first step is trying to restart Home Assistant and see if the problem persists. If it does, look at the log to see what the error is. If you can't figure it out, please [report it](https://github.com/balloob/home-assistant/issues) so we can investigate what is going on.
 
 #### {% linkable_title Problems with components %}
 
@@ -96,7 +97,7 @@ Contents of `lights.yaml`:
 ```yaml
 - platform: hyperion
   host: 192.168.1.98
-  [...]
+  ...
 ```
 
 Contents of `sensors.yaml`:
@@ -108,9 +109,9 @@ Contents of `sensors.yaml`:
 - platform: mqtt
   name: "Door Motion"
   state_topic: "door/motion"
-  [...]
+  ...
 ```
 
 <p class='note'>
-Whenever you report an issue, be aware that we are a group of volunteers that do not have access to every single device in the world nor unlimited time to fix every problem out there.
+Whenever you report an issue, be aware that we are volunteers who do not have access to every single device in the world nor unlimited time to fix every problem out there.
 </p>

--- a/source/getting-started/troubleshooting.markdown
+++ b/source/getting-started/troubleshooting.markdown
@@ -9,20 +9,20 @@ sharing: true
 footer: true
 ---
 
-It can happen that you run into trouble while installing Home Assistant. This page is here to help you figure out the most common problems.
+It can happen that you run into trouble while installing Home Assistant. This page is here to help you solve the most common problems.
 
 
 #### {% linkable_title pip3: command not found %}
 This utility should have been installed as part of the Python 3.4 installation. Check if Python 3.4 is installed by running `python3 --version`. If it is not installed, [download it here](https://www.python.org/getit/).
 
-If you are able to successfully run `python3 --version` but not `pip3`, run the following command instead to install Home Assistant:
+If you are able to successfully run `python3 --version` but not `pip3`, install Home Assistant by running the following command instead:
 
 ```bash
 $ python3 -m pip install homeassistant
 ```
 
 #### {% linkable_title No module named pip %}
-[Pip](https://pip.pypa.io/en/stable/) should come bundled with the latest Python 3 but is ommitted by some distributions. If you are unable to run `python3 -m pip --version` you can install `pip` by [downloading the installer](https://bootstrap.pypa.io/get-pip.py) and run it with Python 3:
+[Pip](https://pip.pypa.io/en/stable/) should come bundled with the latest Python 3 but is omitted by some distributions. If you are unable to run `python3 -m pip --version` you can install `pip` by [downloading the installer](https://bootstrap.pypa.io/get-pip.py) and running it with Python 3:
 
 ```bash
 $ python3 get-pip.py
@@ -63,7 +63,7 @@ $ iptables-save > /etc/network/iptables.rules  # your rules may be saved elsewhe
 ```
 
 #### {% linkable_title Run the development version %}
-If you want to stay on top of the development of Home Assistant then you can upgrade to the `dev` branch. This can result in an unstable system, loss of data, etc, etc.
+If you want to stay on top of the development of Home Assistant then you can upgrade to the `dev` branch. This can result in an unstable system, loss of data, etc. etc.
 
 ```bash
 $ pip3 install --upgrade git+git://github.com/balloob/home-assistant.git@dev


### PR DESCRIPTION
In automation / numeric state, I removed the config lines that used value_template for battery when the condition was for a temp sensor. I would have replaced it with a more valid template, but I haven't used that before, so I'm not sure what it should be. I did add a comment about it though. Add a relevant template back in to the example if you like.