### PR TITLE
Update Sun documentation (`elevation` parameter)

### DIFF
--- a/source/_components/sun.markdown
+++ b/source/_components/sun.markdown
@@ -22,12 +22,12 @@ homeassistant:
   longitude: -117.22743
 
 sun:
-  elevation: 123
+  elevation: 102
 ```
 
 Configuration variables:
 
-- **elevation** (*Optional*): The solar elevation angle is the altitude of the sun. If ommitted will be retrieved from Google Maps.
+- **elevation** (*Optional*): The (physical) elevation of your location, in metres above sea level. If ommitted will be retrieved from Google Maps.
 
 <p class='img'>
 <img src='/images/screenshots/more-info-dialog-sun.png' />
@@ -59,5 +59,6 @@ The sun event need to have the type 'sun', which service to call, which event (s
 
 | State Attributes | Description |
 | --------- | ----------- |
-| `next_rising` | Date and time of the next sun rising
-| `next_setting` | Date and time of the next sun setting
+| `next_rising` | Date and time of the next sun rising (in UTC).
+| `next_setting` | Date and time of the next sun setting (in UTC).
+| `elevation` |  Solar elevation. This is the angle between the sun and the horizon. Negative values mean the sun is below the horizon.


### PR DESCRIPTION
`elevation` parameter provides physical elevation. Solar elevation changes throughout the day and is provided by the `Sun` entity, not a parameter to it.

Clarify parameters: that times given are in UTC (not local time), and the `elevation` provided here is different from the `elevation` parameter above.

Also update provided elevation to that at provided location.