### PR TITLE
fix value_template string  Markdown issue

### DIFF
--- a/source/_components/sensor.mqtt.markdown
+++ b/source/_components/sensor.mqtt.markdown
@@ -56,6 +56,6 @@ sensor:
   state_topic: "owntracks/tablet/tablet"
   name: "Battery Tablet"
   unit_of_measurement: "%"
-  value_template: '{{ value_json.batt }}'
+  value_template: {% raw %}'{{ value_json.batt }}'{% endraw %}
 ```
 


### PR DESCRIPTION
value_template string was getting lost in markdown resulting in web page just showing `value_template: ''`. This should fix the issue...blatent copy from  https://github.com/balloob/home-assistant.io/blob/master/source/_cookbook/track_battery_level.markdown :-)

