### PR TITLE
Zone Documentation - add note re: Home zone & map

### DIFF
--- a/source/_components/zone.markdown
+++ b/source/_components/zone.markdown
@@ -51,6 +51,10 @@ Configuration variables:
 
 If no configuration is given, the `zone` component will create a zone for home. This zone will use location given in the `configuration.yaml` file and have a radius of 100 meters. To override this, create a zone configuration and name it **'Home'**.
 
+<p class='note'>
+Devices that are in the zone **'Home'** will not appear on the map in the Home Assistant UI.
+</p>
+
 #### {% linkable_title Icons %}
 
 It is preferred to pick an icon to use for your zone. Pick any zone that you can find on [materialdesignicons.com](https://materialdesignicons.com/) and prefix the name with `mdi:`. For example `mdi:school`, `mdi:worker`, `mdi:home`, `mdi:cart`, or `mdi:castle`.


### PR DESCRIPTION
Add Note in the Home Assistant Zones Documentation about devices in the **'Home'** zone not showing in the Map View in the Home Assistant UI. This has come up a couple times now on Gitter and in the GitHub Issues.