### PR TITLE
Update autostart.markdown

### DIFF
--- a/source/getting-started/autostart.markdown
+++ b/source/getting-started/autostart.markdown
@@ -20,7 +20,7 @@ footer: true
 <label class='menu-selector synology' for='synology-install'>Synology NAS</label>
 
 <div class='advanced-installs upstart' markdown='1'>
-Many linux distributions use the Upstart system (or similar) for managing daemons. Typically, systems based on Debian 7 or previous use Upstart. This includes Ubuntu releases before 15.04 and all current Raspian releases. If you are unsure if your system is using Upstart, you may check with the following command:
+Many linux distributions use the Upstart system (or similar) for managing daemons. Typically, systems based on Debian 7 or previous use Upstart. This includes Ubuntu releases before 15.04. If you are unsure if your system is using Upstart, you may check with the following command:
 
 ```bash
 $ ps -p 1 -o comm=


### PR DESCRIPTION
Per the link systemd is used by default in Jessie instead of upstart (not specifically for the Pi but still): https://wiki.debian.org/FAQsFromDebianUser#systemd

Running ps -p 1 -o comm= on my pi gives systemd as well.